### PR TITLE
Fixed missing parenthesis.

### DIFF
--- a/hippynn/layers/physics.py
+++ b/hippynn/layers/physics.py
@@ -124,7 +124,7 @@ class AlphaScreening(torch.nn.Module):
 class EwaldRealSpaceScreening(AlphaScreening):
     def __init__(self, alpha):
         warnings.warn("Ewald implementation incomplete, does not include k-space contributions.")
-        super.__init__(alpha)
+        super().__init__(alpha)
 
     def forward(self, pair_dist, radius):
         q = pair_dist / radius
@@ -136,7 +136,7 @@ class EwaldRealSpaceScreening(AlphaScreening):
 class WolfScreening(AlphaScreening):
     def __init__(self, alpha):
         warnings.warn("Wolf implemnetation uses exact derivative of the potential.")
-        super.__init__(alpha)
+        super().__init__(alpha)
 
     def forward(self, pair_dist, radius):
         q = pair_dist / radius


### PR DESCRIPTION
Fix Missing parenthesis in EwaldRealSpaceScreening(AlphaScreening) and WolfScreening(AlphaScreening) in super/base class AlphaScreening initialization.

super.__init__(alpha) -->  super().__init__(alpha)


Example of Issue

`ES = EwaldRealSpaceScreening(alpha=1.0) `

TypeError: descriptor '__init__' requires a 'super' object but received a 'float'