### PR TITLE
Fix a problem with torch RNG when restarting

### DIFF
--- a/hippynn/experiment/serialization.py
+++ b/hippynn/experiment/serialization.py
@@ -65,7 +65,7 @@ def restore_checkpoint(structure, state, restore_db=True):
         structure["database"] = structure["database"].attempt_reload()
 
     structure["metric_tracker"] = state["metric_tracker"]
-    torch.random.set_rng_state(state["torch_rng_state"])
+    torch.random.set_rng_state(state["torch_rng_state"].cpu())
 
     return structure
 


### PR DESCRIPTION
When a model is reloaded to a different CUDA device, an error of `TypeError: RNG state must be a torch.ByteTensor` might be thrown.

For example, originally the model was trained on GPU 1 and now to load it onto GPU 0, per [torch docs](https://pytorch.org/docs/stable/generated/torch.load.html), you can do `load_checkpoint_from_cwd(map_location={'cuda:1':'cuda:0'})`, which works fine. Unfortunately, this way requires users to know which GPU was used, and this is obviously a problem to automation.

However, using `load_checkpoint_from_cwd(map_location=torch.device(0))` or `load_checkpoint_from_cwd(map_location=lambda storage, loc: storage.cuda(0))` will throw an error of `TypeError: RNG state must be a torch.ByteTensor`.

The codes related are

hippynn.experiment.serialization.restore_checkpoint

```python
torch.random.set_rng_state(state["torch_rng_state"])
```

and torch.random.set_rng_state

```python
def set_rng_state(new_state: torch.Tensor) -> None:
    r"""Sets the random number generator state.

    .. note: This function only works for CPU. For CUDA, please use
             torch.manual_seed(seed), which works for both CPU and CUDA.

    Args:
        new_state (torch.ByteTensor): The desired state
    """
    default_generator.set_state(new_state)
```

`state["torch_rng_state"]` will be a tensor on GPU 0 for the latter two ways of `map_location`

```python
tensor([13, 78, 72,  ...,  0,  0,  0], device=‘cuda:0’, dtype=torch.uint8
```

but it will stay on CPU with `{'cuda:1':'cuda:0'}`

```python
tensor([13, 78, 72,  ...,  0,  0,  0], dtype=torch.uint8
```

Forcing the tensor to be transferred to CPU solves the problem, and RNG is originally on CPU anyway.