### PR TITLE
Transparent plot, doc update, and some misc updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 */test_model*
 __pycache__/
 *.pyc
+build/
+hippynn.egg-info/*

--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -1,0 +1,35 @@
+.wy-table-responsive {
+    overflow: visible;
+    font-size: 20px;
+}
+
+.wy-table-responsive table td {
+    white-space: normal;
+    font-size: 26px;
+}
+
+.wy-table-responsive table th {
+    white-space: normal;
+    font-style: italic;
+    text-align: center;
+}
+
+.wy-nav-content {
+    max-width: 1000px;
+    width: 80%;
+}
+
+
+/*
+.wy-nav-side {
+    left: 0px;
+    width: 280px;
+    overflow-x: auto;
+}
+*/
+
+
+.rst-content table.docutils caption {
+    text-align: center;
+    font-size: 100%;
+}

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -59,10 +59,19 @@ html_theme = "sphinx_rtd_theme"
 html_theme_options = {
     "navigation_depth": -1,
     "prev_next_buttons_location": "both",
+    "navigation_with_keys": True,
 }
 
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = []
+html_static_path = ["_static"]
+
+# These paths are either relative to html_static_path
+# or fully qualified paths (eg. https://...)
+html_css_files = [
+    "css/custom.css",
+]
+
+# html_logo = "_static/logo.svg"

--- a/docs/source/user_guide/settings.rst
+++ b/docs/source/user_guide/settings.rst
@@ -48,6 +48,14 @@ The following settings are available:
        | '.pdf', '.png', '.jpg'
      - .pdf
      - Yes
+   * - TRANSPARENT_PLOT
+     - | Whether to plot the figures
+       | with a background or not.
+       | Note that transparent background
+       | does not work on all file types.
+     - | True, False
+     - False
+     - Yes
    * - USE_CUSTOM_KERNELS
      - | Use custom kernels with numba or cupy.
        | Auto tries to detect the

--- a/docs/source/user_guide/settings.rst
+++ b/docs/source/user_guide/settings.rst
@@ -40,13 +40,12 @@ The following settings are available:
      - .pdf
      - Yes
    * - TRANSPARENT_PLOT
-     - Whether to plot the figures with a background or not. Note that transparent background does not work on all file types.
-     - True, False
-     - False
+     - Whether to plot figures with a background or not. Note that transparent background does not work on all file types.
+     - true, false
+     - false
      - Yes
    * - USE_CUSTOM_KERNELS
-     - Use custom kernels with numba or cupy. Auto tries to detect the installation of numba or cupy.
-       for more info see :doc:`/user_guide/ckernels`.
+     - Use custom kernels with numba or cupy. Auto tries to detect the installation of numba or cupy. For more info see :doc:`/user_guide/ckernels`.
      - auto, true, false, pytorch, numba, cupy
      - auto
      - Not directly, use :func:`~hippynn.custom_kernels.set_custom_kernels`

--- a/docs/source/user_guide/settings.rst
+++ b/docs/source/user_guide/settings.rst
@@ -21,7 +21,7 @@ If possible, this is indicated in the `dynamic` column in the following table.
 The following settings are available:
 
 .. list-table:: Hippynn Settings Summary
-   :widths: 10 10 10 10 10
+   :widths: 60 100 50 25 60
    :header-rows: 1
 
    * - Variable
@@ -30,59 +30,38 @@ The following settings are available:
      - Default
      - Dynamic
    * - PROGRESS
-     - | Progress bars function during
-       | training, evaluation, and prediction
+     - Progress bars function during training, evaluation, and prediction
      - tqdm, none
      - tqdm
-     - | Yes, but assign this to a
-       | generator-wrapper such as ``tqdm.tqdm``,
-       | or with a python ``None`` to disable.
-       | The wrapper must accept ``tqdm`` arguments,
-       | although it technically doesn't have to
-       | do anything with them.
+     - Yes, but assign this to a generator-wrapper such as ``tqdm.tqdm``, or with a python ``None`` to disable. The wrapper must accept ``tqdm`` arguments, although it technically doesn't have to do anything with them.
    * - DEFAULT_PLOT_FILETYPE
-     - | File type to use for plots when
-       | not explicitly specified
-     - | Filetypes supported
-       | by matplotlib e.g.
-       | '.pdf', '.png', '.jpg'
+     - File type to use for plots when not explicitly specified
+     - Filetypes supported by matplotlib e.g. '.pdf', '.png', '.jpg'
      - .pdf
      - Yes
    * - TRANSPARENT_PLOT
-     - | Whether to plot the figures
-       | with a background or not.
-       | Note that transparent background
-       | does not work on all file types.
-     - | True, False
+     - Whether to plot the figures with a background or not. Note that transparent background does not work on all file types.
+     - True, False
      - False
      - Yes
    * - USE_CUSTOM_KERNELS
-     - | Use custom kernels with numba or cupy.
-       | Auto tries to detect the
-       | installation of numba or cupy.
-       | for more info see :doc:`/user_guide/ckernels`.
+     - Use custom kernels with numba or cupy. Auto tries to detect the installation of numba or cupy.
+       for more info see :doc:`/user_guide/ckernels`.
      - auto, true, false, pytorch, numba, cupy
      - auto
      - Not directly, use :func:`~hippynn.custom_kernels.set_custom_kernels`
    * - WARN_LOW_DISTANCES
-     - | Warn if atom distances are low
-       | compared to current radial
-       | sensitivity parameters.
+     - Warn if atom distances are low compared to current radial sensitivity parameters.
      - true, false
      - true
      - yes
    * - DEBUG_LOSS_BROADCAST
-     - | Warn if quantities in the loss
-       | broadcast badly against each
-       | other.
+     - Warn if quantities in the loss broadcast badly against each other.
      - true, false
      - false
      - no
    * - DEBUG_GRAPH_BROADCAST
-     - | Print high verbose information about
-       | the execution of a graph module.
-       | Don't turn this on unless something
-       | is going very wrong.
+     - Print high verbose information about the execution of a graph module. Don't turn this on unless something is going very wrong.
      - true, false
      - false
      - no

--- a/hippynn/__init__.py
+++ b/hippynn/__init__.py
@@ -24,3 +24,5 @@ from .experiment import setup_and_train
 from . import custom_kernels
 
 from . import pretraining
+
+from . import tools

--- a/hippynn/_settings_setup.py
+++ b/hippynn/_settings_setup.py
@@ -42,27 +42,28 @@ def progress_handler(prog_str):
 
 
 def kernel_handler(kernel_string):
-    
+
     kernel_string = kernel_string.lower()
-    
+
     kernel = {
-        "0":False,
-        "false":False,
-        "pytorch":False,
-        "1":True,
-        "true":True,
-        }.get(kernel_string,kernel_string)
-    
-    if kernel not in [True,False,"auto","cupy","numba"]:
+        "0": False,
+        "false": False,
+        "pytorch": False,
+        "1": True,
+        "true": True,
+    }.get(kernel_string, kernel_string)
+
+    if kernel not in [True, False, "auto", "cupy", "numba"]:
         warnings.warn(f"Unrecognized custom kernel option: {kernel_string}. Setting custom kernels to 'auto'")
         kernel = "auto"
-    
+
     return kernel
 
 
 default_settings = {
     "PROGRESS": (TQDM_PROGRESS, progress_handler),
     "DEFAULT_PLOT_FILETYPE": (".pdf", str),
+    "TRANSPARENT_PLOT": (False, strtobool),
     "DEBUG_LOSS_BROADCAST": (False, strtobool),
     "DEBUG_GRAPH_EXECUTION": (False, strtobool),
     "DEBUG_NODE_CREATION": (False, strtobool),

--- a/hippynn/plotting/plotmaker.py
+++ b/hippynn/plotting/plotmaker.py
@@ -4,6 +4,7 @@ import warnings
 from matplotlib import pyplot as plt
 
 from ..graphs import GraphModule
+from .. import settings
 
 
 class PlotMaker:
@@ -45,7 +46,7 @@ class PlotMaker:
                 if plotter.saved:
                     file = os.path.join(location, plotter.saved)
                     print("Saving plot at {}".format(file))
-                    fig.savefig(file)
+                    fig.savefig(file, transparent=settings.TRANSPARENT_PLOT)
                 plt.close(fig)
 
     def make_full_location(self, sub_location):


### PR DESCRIPTION
1. Implemented the transparent plot option as a library setting, and defaults to `False`. One note though, transparent PDF does work, but most of the pdf reader will automatically add a white background, which looks like the keyword isn't working. The "library settings" section of the doc is updated as well.
2. Stylish the docs with a css file. The default RTD theme has a fixed width of 800 px, which is too narrow for the tables to show properly. Even worse, there is no way to narrow the sidebar, except truncating it or remove it completely. So I decided to lift the limit a little bit. Now the width of the whole page is 80% or 1000 px, whichever is smaller. For anything that is > 1280 pixels horizontally, 1000 will be used. (It will suck for sure on phones or vertically used 1080p monitors, but it sucks even without this PR...) The RTD theme is way too restrictive. They even refuse to merge this... https://github.com/readthedocs/sphinx_rtd_theme/pull/337 Probably nothing more we can do.

   A comparison

   | Before | After |
   | ----------- | ----------- |
   | ![before](https://user-images.githubusercontent.com/15900605/197693331-8a9d133b-bd9d-4a2b-96ce-94c974add978.png) | ![after](https://user-images.githubusercontent.com/15900605/197693367-12109a7b-e1f1-4751-887f-6105bf58eb0d.png) |

   A bonus point is that we don't have to hard code line breaks anymore. The texts will be wrapped.

3. Misc updates. See if you like it.
   1. Updated `.gitignore` to exclude files from `pip install -e`. I guess it won't be useful for normal users, but for the development branch, it should be super useful.
   2. Add tools.py to __init__.py, so you get auto-completion for stuff like `hippynn.tools.log_terminal`. I know it's trivial 😂