### PR TITLE
Proper device handling for restart

### DIFF
--- a/docs/source/_static/css/custom.css
+++ b/docs/source/_static/css/custom.css
@@ -33,3 +33,21 @@
     text-align: center;
     font-size: 100%;
 }
+
+/* for ordered list numerals */
+.rst-content section ol.arabic li {
+    list-style: decimal;
+}
+
+.rst-content section ol.arabic li li {
+    list-style: upper-roman;
+}
+
+.rst-content section ol.arabic li li li {
+    list-style: lower-alpha;
+    
+}
+
+.red {
+    color: red !important;
+}

--- a/docs/source/examples/restarting.rst
+++ b/docs/source/examples/restarting.rst
@@ -2,7 +2,7 @@
 Restarting training
 ===================
 
-You may want to restart training from a previous state. (e.g. due to job length
+You may want to restart training from a previous state, e.g., due to job length
 constraints on HPC systems.
 
 By default, hippynn saves checkpoint information for the best model found
@@ -22,13 +22,131 @@ the metrics of the experiment so far. This can be seen by breaking down
                                controller,
                                metrics)
 
+Note that the database is always placed on CPU after restarting. To transfer it
+to GPU, you have to do it explicitly through ``database.send_do_device(desired_device)``.
+
+There are two types restart,
+
+1. :ref:`A simple restart <simple>`,
+2. :ref:`A cross-device restart <cross>`, where tensors will be mapped to a
+   different device.
+
+.. _simple:
+
+Simple restart
+--------------
+
 To restart training later, you can use the following::
 
-    from hippynn.experiment.serialziation import load_checkpoint
+    from hippynn.experiment.serialization import load_checkpoint
     check = load_checkpoint('./experiment_structure.pt','./best_checkpoint.pt')
     train_model(**check)
 
-If your database is not Restartable, you wil have to explicitly reload it and pass it to ``train_model``, as well.
+or to use the default filename and load from the current directory::
 
-The checkpoint file contains and resets the torch RNG state as well.
+    from hippynn.experiment.serialization import load_checkpoint_from_cwd
+    check = load_checkpoint_from_cwd()
+    train_model(**check)
 
+If your database is not :class:`~hippynn.databases.restarter.Restartable`, you
+will have to explicitly reload it and pass it to ``train_model``, as well. The
+dictionary containing the database information is stored as ``training_modules.evaluator.db_info``,
+so you can use this dictionary to easily reload your database.
+
+The checkpoint file contains and resets the torch RNG state.
+
+Alternatively, it is possible to load the model only::
+
+    from hippynn.experiment.serialization import load_model_from_cwd
+    model = load_model_from_cwd()
+
+The returned ``model`` object will have the original model with the best
+parameters loaded. Of course, to actually use the model, you need create other
+object manually.
+
+.. _cross:
+
+Cross-device restart
+--------------------
+
+.. role:: red
+
+**A quick tip**: to avoid cross-device restarts as much as you can, use the
+environment variable ``CUDA_VISIBLE_DEVICES`` from shell or set it before
+importing hippynn (:red:`Important !`), instead of setting devices inside your
+script. In this case, if, for example, only 1 GPU is used, it will always be
+labeled as 0, no matter physically which device is used.
+
+#######
+
+It is a lot trickier to reload a model or checkpoint across devices. At this
+moment, we provide the following possibilities.
+
+#. You explicitly know the original and new devices used. For example, to 
+   transfer all tensors that are on GPU 1 to GPU 0::
+   
+    from hippynn.experiment.serialization import load_checkpoint_from_cwd
+    check = load_checkpoint_from_cwd(map_location={"cuda:1": "cuda:0"})
+    train_model(**check)
+
+   The dictionary is a explicitly mapping for the old device (key) to the new
+   device (value). So if a tensor that is not on the old device will not be
+   transferred. For example, in the above example, tensors on CPU will stay.
+
+   Note that:
+
+   #. As aforementioned, the database (if restarted) will be loaded to CPU. An
+      manual transfer is still needed.
+   #. If ``map_location`` is used and the value is anything other than ``None``,
+      we will not handle any exception. The argument will directly be passed to
+      ``torch.load``. Use this only if you are 100% about the devices.
+
+   For more details of this option, check `torch load docs`_. 
+
+   .. _torch load docs: https://pytorch.org/docs/stable/generated/torch.load.html
+
+#. Leave the problem to us via the ``model_device`` option. If this option is
+   given, all tensors will first be transferred to CPU and then transferred to
+   ``model_device`` if necessary. Note only some tensors will be transferred to
+   GPU if a GPU is available.
+
+   #. ``model_device="auto"`` :func:`~hippynn.tools.device_fallback` will be
+      used to automatically select the best device. If there is GPU, GPU will be
+      selected. If there are multiple GPUs, GPU 0 will be chosen. Otherwise, we
+      will use CPU.
+
+   #. ``model_device="cpu"`` or ``model_device=0`` or ``model_device="cuda:1"``
+      or ``model_device=torch.device(2)`` Given device will be used as to load
+      tensors. Make sure the target device is available.
+
+   :func:`~hippynn.experiment.serialization.load_model_from_cwd` works exactly
+   the same.
+
+   Here are a list of objects and their final device after loading.
+
+   .. list-table::
+      :widths: 40 30
+      :header-rows: 1
+
+      * - Objects
+        - Destinations
+      * - ``training_modules.model``
+        - ``model_device``
+      * - ``training_modules.loss``
+        - ``model_device``
+      * - ``training_modules.evaluator.model``
+        - ``model_device``
+      * - ``controller.optimizer``
+        - Partially to ``model_device``
+      * - ``database``
+        - CPU
+      * - Not mentioned
+        - CPU
+
+   Again, if you want to load your database to GPU, a manual transfer is
+   necessary.
+
+Warning: please do not use something like ``map_location=torch.device(0)``, as
+this will map all tensors to GPU 0 and breaks the RNG which only supports a CPU
+tensor. Doing so, you will see errors like ``TypeError: RNG state must be a torch.ByteTensor``.
+Obviously, moving everything to CPU with ``map_location="cpu"`` always works.

--- a/docs/source/examples/restarting.rst
+++ b/docs/source/examples/restarting.rst
@@ -14,16 +14,25 @@ the metrics of the experiment so far. This can be seen by breaking down
 :func:`~hippynn.experiment.setup_training`, and :func:`~hippynn.experiment.routines.train_model`::
 
     from hippynn.experiment import setup_training, train_model
-    training_modules,controller,metrics = setup_training(training_modules=training_modules,
-                setup_params=experiment_params,
-                )
-    hippynn.experiment.train_model(training_modules,
-                               database,
-                               controller,
-                               metrics)
+    training_modules, controller, metrics = setup_training(
+        training_modules=training_modules,
+        setup_params=experiment_params,
+    )
+    hippynn.experiment.train_model(
+        training_modules,
+        database,
+        controller,
+        metrics,
+        callbacks,
+        batch_callbacks,
+    )
 
 Note that the database is always placed on CPU after restarting. To transfer it
 to GPU, you have to do it explicitly through ``database.send_do_device(desired_device)``.
+
+Also note that it is not possible in general to save callbacks, so when using
+this function, you need reconstruct your previous callbacks manually or set the
+two parameters to ``None``.
 
 There are two types restart,
 
@@ -39,14 +48,14 @@ Simple restart
 To restart training later, you can use the following::
 
     from hippynn.experiment.serialization import load_checkpoint
-    check = load_checkpoint('./experiment_structure.pt','./best_checkpoint.pt')
-    train_model(**check)
+    check = load_checkpoint("./experiment_structure.pt", "./best_checkpoint.pt")
+    train_model(**check, callbacks=None, batch_callbacks=None)
 
-or to use the default filename and load from the current directory::
+or to use the default filenames and load from the current directory::
 
     from hippynn.experiment.serialization import load_checkpoint_from_cwd
     check = load_checkpoint_from_cwd()
-    train_model(**check)
+    train_model(**check, callbacks=None, batch_callbacks=None)
 
 If your database is not :class:`~hippynn.databases.restarter.Restartable`, you
 will have to explicitly reload it and pass it to ``train_model``, as well. The

--- a/docs/source/examples/restarting.rst
+++ b/docs/source/examples/restarting.rst
@@ -18,7 +18,7 @@ the metrics of the experiment so far. This can be seen by breaking down
         training_modules=training_modules,
         setup_params=experiment_params,
     )
-    hippynn.experiment.train_model(
+    train_model(
         training_modules,
         database,
         controller,
@@ -99,13 +99,14 @@ moment, we provide the following possibilities.
     train_model(**check)
 
    The dictionary is a explicitly mapping for the old device (key) to the new
-   device (value). So if a tensor that is not on the old device will not be
-   transferred. For example, in the above example, tensors on CPU will stay.
+   device (value). So a tensor that is not on the old device will not be
+   transferred. For example, in the above example, tensors on CPU will stay on
+   CPU.
 
    Note that:
 
-   #. As aforementioned, the database (if restarted) will be loaded to CPU. An
-      manual transfer is still needed.
+   #. As aforementioned, the database (if restarted) is always loaded onto CPU.
+      A manual transfer is still needed.
    #. If ``map_location`` is used and the value is anything other than ``None``,
       we will not handle any exception. The argument will directly be passed to
       ``torch.load``. Use this only if you are 100% about the devices.
@@ -147,6 +148,8 @@ moment, we provide the following possibilities.
         - ``model_device``
       * - ``controller.optimizer``
         - Partially to ``model_device``
+      * - ``training_modules.evaluator.loss``
+        - CPU
       * - ``database``
         - CPU
       * - Not mentioned
@@ -155,7 +158,12 @@ moment, we provide the following possibilities.
    Again, if you want to load your database to GPU, a manual transfer is
    necessary.
 
-Warning: please do not use something like ``map_location=torch.device(0)``, as
-this will map all tensors to GPU 0 and breaks the RNG which only supports a CPU
-tensor. Doing so, you will see errors like ``TypeError: RNG state must be a torch.ByteTensor``.
-Obviously, moving everything to CPU with ``map_location="cpu"`` always works.
+Note that if non-None values are assigned to both ``map_location`` and
+``model_device``, a ``TypeError`` will be raised, as both keywords will likely
+conflict with each other.
+
+:red:`Warning`: Please do not directly use something like
+``map_location=torch.device(0)``, as this will map all tensors to GPU 0 and
+breaks the RNG which only supports a CPU tensor. Doing so, you will see errors
+like ``TypeError: RNG state must be a torch.ByteTensor``. Obviously, moving
+everything to CPU with ``map_location="cpu"`` always works.

--- a/hippynn/experiment/device.py
+++ b/hippynn/experiment/device.py
@@ -1,0 +1,54 @@
+"""
+This file is used to host the function `set_devices`, as it is needed by both
+serialization and routines. We may find a better place for this function in the
+future.
+"""
+from typing import Tuple, Union
+
+import torch
+
+from ..graphs import GraphModule
+from .evaluator import Evaluator
+
+
+def set_devices(
+    model: GraphModule,
+    loss: GraphModule,
+    evaluator: Evaluator,
+    optimizer: torch.optim.Optimizer,
+    device: Union[torch.device, str, Tuple, list],
+) -> Tuple:
+    """Sets the model, loss, and optimizer to the specified device if necessary.
+    Evaluation loss is performed on CPU.
+
+    :param model: current model on CPU
+    :type model: GraphModule
+    :param loss: current loss module on CPU
+    :type loss: GraphModule
+    :param evaluator: evaluator
+    :type evaluator: Evaluator
+    :param optimizer: optimizer with state dictionary on CPU
+    :type optimizer: torch.optim.Optimizer
+    :param device: target device for training. If device is a tuple or list, wrap
+        the model using torch.nn.DataParallel and use the first specified device
+        as the "primary: one.
+    :type device: Union[torch.devices, string, tuple, list]
+    :return: model, evaluator, optimizer
+    :rtype: Tuple
+    """
+    print("Using device: ", device)
+    if isinstance(device, (tuple, list)):
+        model = torch.nn.DataParallel(model, device_ids=device)
+        print("Using multi GPU compute on devices:", device)
+        device = torch.device(device[0])
+    device = torch.device(device)  # Will throw a more explicit error if the device specification is invalid
+
+    model.to(device)
+    loss.to(device)
+    evaluator.loss.cpu()
+    evaluator.model_device = device
+    evaluator.model = model
+    # reload the state dict after model transfer
+    optimizer.load_state_dict(optimizer.state_dict())
+
+    return model, evaluator, optimizer

--- a/hippynn/experiment/serialization.py
+++ b/hippynn/experiment/serialization.py
@@ -123,7 +123,7 @@ def load_checkpoint(structure_fname, state_fname, restore_db=True, map_location=
         structure_fname (str): name of the structure file
         state_fname (str): name of the state file
         restore_db (bool, optional): restore database or not. Defaults to True.
-        map_location (Union[tr, dict, torch.device], optional): device mapping argument for torch.load. Defaults to None.
+        map_location (Union[str, dict, torch.device], optional): device mapping argument for torch.load. Defaults to None.
         model_device (Union[int, str, torch.device], optional): automatically handle device mapping. Defaults to None.
 
     Returns:
@@ -151,14 +151,17 @@ def load_checkpoint(structure_fname, state_fname, restore_db=True, map_location=
         return structure
 
 
-def load_checkpoint_from_cwd(**kwargs):
-    """
-    See load_checkpoint, but using default filenames.
-    :param kwargs:
+def load_checkpoint_from_cwd(map_location=None, model_device=None, **kwargs):
+    """Same as `load_checkpoint`, but using default filenames.
 
-    :return:
+    Args:
+        map_location (Union[str, dict, torch.device], optional): device mapping argument for torch.load. Defaults to None.
+        model_device (Union[int, str, torch.device], optional): automatically handle device mapping. Defaults to None.
+
+    Returns:
+        dict: experiment structure
     """
-    return load_checkpoint(DEFAULT_STRUCTURE_FNAME, "best_checkpoint.pt", **kwargs)
+    return load_checkpoint(DEFAULT_STRUCTURE_FNAME, "best_checkpoint.pt", map_location, model_device, **kwargs)
 
 
 def load_model_from_cwd(map_location=None, model_device=None, **kwargs):

--- a/hippynn/experiment/serialization.py
+++ b/hippynn/experiment/serialization.py
@@ -85,15 +85,13 @@ def restore_checkpoint(structure: dict, state: dict, restore_db=True):
 def check_mapping_devices(map_location, model_device) -> Tuple:
     """Check options for restarting across devices
 
-    Args:
-        map_location (Union[str, dict, torch.device, callable]): device mapping argument for torch.load. Defaults to None.
-        model_device (Union[int, str, torch.device]): automatically handle device mapping. Defaults to None.
-
-    Raises:
-        TypeError: if both map_location and model_device are specified
-
-    Returns:
-        Tuple: processed map_location and model_device
+    :param map_location: device mapping argument for torch.load. Defaults to None.
+    :type map_location: Union[str, dict, torch.device, callable]
+    :param model_device: automatically handle device mapping. Defaults to None.
+    :type model_device: Union[int, str, torch.device]
+    :raises TypeError: if both map_location and model_device are specified
+    :return: processed map_location and model_device
+    :rtype: Tuple
     """
     # if both are none, no transfer across device happens, directly pass map_location (which is None) to torch.load
     if model_device is not None:
@@ -111,7 +109,7 @@ def load_saved_tensors(structure_fname: str, state_fname: str, **kwargs) -> Tupl
 
     :param structure_fname: name of the structure file
     :param state_fname: name of the state file
-    :return:  loaded dictionaries of checkpoint and model parameters
+    :return: loaded dictionaries of checkpoint and model parameters
     :rtype: Tuple[dict, dict]
     """
 

--- a/hippynn/experiment/serialization.py
+++ b/hippynn/experiment/serialization.py
@@ -18,7 +18,11 @@ from .metric_tracker import MetricTracker
 DEFAULT_STRUCTURE_FNAME = "experiment_structure.pt"
 
 
-def create_state(model: GraphModule, controller: PatienceController, metric_tracker: MetricTracker):
+def create_state(
+    model: GraphModule,
+    controller: PatienceController,
+    metric_tracker: MetricTracker,
+) -> dict:
     """Create an experiment state dictionary.
 
     :param model: current model
@@ -36,8 +40,11 @@ def create_state(model: GraphModule, controller: PatienceController, metric_trac
 
 
 def create_structure_file(
-    training_modules: TrainingModules, database: Database, controller: PatienceController, fname=DEFAULT_STRUCTURE_FNAME
-):
+    training_modules: TrainingModules,
+    database: Database,
+    controller: PatienceController,
+    fname=DEFAULT_STRUCTURE_FNAME,
+) -> None:
     """
     Save an experiment structure. (i.e. full model, not just state_dict).
 
@@ -59,7 +66,7 @@ def create_structure_file(
         torch.save(structure, pfile)
 
 
-def restore_checkpoint(structure: dict, state: dict, restore_db=True):
+def restore_checkpoint(structure: dict, state: dict, restore_db=True) -> dict:
     """
 
     :param structure: experiment structure object
@@ -67,7 +74,6 @@ def restore_checkpoint(structure: dict, state: dict, restore_db=True):
     :param restore_db: Attempt to restore database (true/false)
 
     :return: experiment structure
-    :rtype: dict
     """
 
     structure["training_modules"][0].load_state_dict(state["model"])
@@ -82,16 +88,14 @@ def restore_checkpoint(structure: dict, state: dict, restore_db=True):
     return structure
 
 
-def check_mapping_devices(map_location, model_device) -> Tuple:
-    """Check options for restarting across devices
+def check_mapping_devices(map_location, model_device):
+    """
+    Check options for restarting across devices.
 
-    :param map_location: device mapping argument for torch.load. Defaults to None.
-    :type map_location: Union[str, dict, torch.device, callable]
-    :param model_device: automatically handle device mapping. Defaults to None.
-    :type model_device: Union[int, str, torch.device]
+    :param map_location: device mapping argument for torch.load.
+    :param model_device: automatically handle device mapping.
     :raises TypeError: if both map_location and model_device are specified
     :return: processed map_location and model_device
-    :rtype: Tuple
     """
     # if both are none, no transfer across device happens, directly pass map_location (which is None) to torch.load
     if model_device is not None:
@@ -110,7 +114,6 @@ def load_saved_tensors(structure_fname: str, state_fname: str, **kwargs) -> Tupl
     :param structure_fname: name of the structure file
     :param state_fname: name of the state file
     :return: loaded dictionaries of checkpoint and model parameters
-    :rtype: Tuple[dict, dict]
     """
 
     with open(structure_fname, "rb") as pfile:
@@ -123,21 +126,18 @@ def load_saved_tensors(structure_fname: str, state_fname: str, **kwargs) -> Tupl
 
 def load_checkpoint(
     structure_fname: str, state_fname: str, restore_db=True, map_location=None, model_device=None, **kwargs
-):
-    """Load checkpoint file from given filename
+) -> dict:
+    """
+    Load checkpoint file from given filename.
 
-    For details on how to use this function, please check the documentations.
+    For details more information on to use this function, see :doc:`/examples/restarting`.
 
     :param structure_fname: name of the structure file
     :param state_fname: name of the state file
     :param restore_db: restore database or not, defaults to True
-    :type restore_db: bool, optional
     :param map_location: device mapping argument for ``torch.load``, defaults to None
-    :type map_location: Union[str, dict, torch.device, Callable], optional
     :param model_device: automatically handle device mapping. Defaults to None, defaults to None
-    :type model_device: Union[int, str, torch.device], optional
     :return: experiment structure
-    :rtype: dict
     """
 
     # we need keep the original map_location value for the if
@@ -159,8 +159,9 @@ def load_checkpoint(
         return structure
 
 
-def load_checkpoint_from_cwd(map_location=None, model_device=None, **kwargs):
-    """Same as ``load_checkpoint``, but using default filenames.
+def load_checkpoint_from_cwd(map_location=None, model_device=None, **kwargs) -> dict:
+    """
+    Same as ``load_checkpoint``, but using default filenames.
 
     :param map_location: device mapping argument for ``torch.load``, defaults to None
     :type map_location: Union[str, dict, torch.device, Callable], optional
@@ -175,7 +176,8 @@ def load_checkpoint_from_cwd(map_location=None, model_device=None, **kwargs):
 
 
 def load_model_from_cwd(map_location=None, model_device=None, **kwargs) -> GraphModule:
-    """Only load model from current working directory.
+    """
+    Only load model from current working directory.
 
     :param map_location: device mapping argument for ``torch.load``, defaults to None
     :type map_location: Union[str, dict, torch.device, Callable], optional

--- a/hippynn/experiment/serialization.py
+++ b/hippynn/experiment/serialization.py
@@ -145,6 +145,9 @@ def load_checkpoint(structure_fname, state_fname, restore_db=True, map_location=
         structure["training_modules"].loss.to(model_device)
         structure["training_modules"].evaluator.model_device = model_device
         structure["training_modules"].evaluator.model = structure["training_modules"].model
+        for _, v in structure["controller"].optimizer.state_dict()["state"].items():
+            v["exp_avg"] = v["exp_avg"].to(model_device)
+            v["exp_avg_sq"] = v["exp_avg_sq"].to(model_device)
         return structure
 
 


### PR DESCRIPTION
@lubbersnick I guess it's still too early to merge for two reasons, 
1. More tests are needed. I haven't found any issue, but I can always miss something.
2. Doc update is still missing.

However, I decided to open this PR, so at least you can review the code, and someone might be able to test it.

The core part is basically the same as we have discussed, but I split the codes into multiple functions.

* Two hidden functions
  1. ` __check_mapping_devices(map_location, model_device)` which checks the options and assign values if necessary.
  2. `__load_saved_tensors(structure_fname, state_fname, **kwargs)` which loads the tensors from disk
* `load_checkpoint` and `local_model_from_cwd` will call these two functions. Actually, the first few lines of loading checkpoint and model are exactly the same. **Worth wrapping these lines again?**

Additionally, I took a look at `experiment.routines.set_devices`, and mimicked its behavior.

```python
        structure["training_modules"].model.to(model_device)
        structure["training_modules"].loss.to(model_device)
        structure["training_modules"].evaluator.model_device = model_device
        structure["training_modules"].evaluator.model = structure["training_modules"].model
```

Not sure if the last two lines are important or not.

Tests using a model training on GPU 1. Here are the results

|  Options                                                      | Expected behavior            | Actual behavior              |
|---------------------------------------------------------------|------------------------------|------------------------------|
| `load_checkpoint_from_cwd(map_location={"cuda:1": "cuda:0"})` | model on GPU 0               | model on GPU 0               |
| `load_checkpoint_from_cwd(map_location=torch.device(0))`      | failure because of rng_state | failure because of rng_state |
| `load_checkpoint_from_cwd(model_device=2)`                    | model on GPU 2               | model on GPU 2               |
| `load_checkpoint_from_cwd(model_device="auto")`               | model on GPU 0               | model on GPU 0               |
| `load_checkpoint_from_cwd(model_device="cpu")`                | model on CPU                 | model on CPU                 |
| `load_checkpoint_from_cwd()`                                  | model on GPU 1               | model on GPU 1               |

Similar tests were done for `load_model_from_cwd` as well.

One thing to note, restoring database always keeps the database on CPU, so my concern was totally unnecessary. Even doing `map_location={"cuda:1": "cuda:0"}` will keep the database originally on GPU 1 to GPU 0. 