### PR TITLE
Auto build docs via Actions

### DIFF
--- a/.github/workflows/auto_doc_build.yml
+++ b/.github/workflows/auto_doc_build.yml
@@ -1,0 +1,50 @@
+name: Auto build HIPPYNN docs and publish on GitHub Pages
+
+on:
+  push:
+    branches:    
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    # Standard drop-in approach that should work for most people.
+    - uses: ammaraskar/sphinx-action@master
+      with:
+        # FIXME: hot to build with mocking torch?
+        # use CPU only torch as this action will be likely for doc building only
+        pre-build-command: "pip3 install -U sphinx sphinx_rtd_theme graphviz ase torch --extra-index-url https://download.pytorch.org/whl/cpu && pip install ."
+        docs-folder: "docs/"
+        # a new target that always builds api_doc first
+        build-command: "make html_all"
+    # Create an artifact of the html output.
+    - uses: actions/upload-artifact@v1
+      with:
+        name: DocumentationHTML
+        path: docs/build/html/
+    # Publish built docs to gh-pages branch.
+    # ===============================
+    - name: Commit documentation changes
+      run: |
+        git clone https://github.com/${{ github.repository }}.git --branch gh-pages --single-branch gh-pages
+        cp -r docs/build/html/* gh-pages/
+        cd gh-pages
+        touch .nojekyll
+        git config --local user.email "action@github.com"
+        git config --local user.name "GitHub Action"
+        git add .
+        git commit -m "Update documentations" -a || true
+        # The above command will fail if no changes were present, so we ignore
+        # that.
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        branch: gh-pages
+        directory: gh-pages
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+    # ===============================

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -24,6 +24,10 @@ cleanapi:
 	@rm source/api_documentation/hippynn*.rst
 .PHONY: cleanapi
 
+# make sure api_doc is always built first
+html_all: apidoc html
+.PHONY: html_all
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile


### PR DESCRIPTION
Currently two ways to trigger this action

* a push to main
* manual trigger from the `Actions` tab

The new target in Makefile is renamed to "html_all", which does `make apidoc && make html`. Original `make html` should work as before.
"all" alone will be ambiguous. It may refer to all file types. 

I think it makes sense to directly add this to main or an orphan branch which only hosts the actions.

* Manual trigger only works the default branch. If we add this to another branch, there is no way to manually trigger this action unless you switch default to that branch. And there is no push to main at this moment, so we won't have any docs built for a long time.
* All actions in different branches will (probably) be triggered at the same time, so we either have only one copy of actions on main, or one copy on a separated branch which is only used to host all kinds of actions. Let me if you want to opt for the second way. We can create an orphan branch to do this to minimize "pollutions" to the main codebase.


To make this work, you need create an orphan branch first. Let's say it's called `gh-pages` like what's in the action. As you need something added to commit, you can create a dummy index.html.

```shell
git switch --orphan gh-pages
touch index.html
git add .
git commit -m 'initial commit'
git push --set-upstream origin gh-pages
```

Then on GitHub, point pages to this branch
![image](https://user-images.githubusercontent.com/15900605/199864577-f75bd3ac-f4b9-46f3-9b96-283967349a8b.png)

Once this PR is merged to main, https://lanl.github.io/hippynn/ should show our docs. The action will take about 3 minutes to finish.

Future CI should be almost the same workflow, but we will want to check the main branch, development branch, and PRs.