### PR TITLE
unnecessary index type constraint for vectors

### DIFF
--- a/hippynn/graphs/nodes/physics.py
+++ b/hippynn/graphs/nodes/physics.py
@@ -229,7 +229,6 @@ class VecMag(ExpandParents, AutoNoKw, SingleNode):
 
     _parent_expander.assertlen(1)
     _parent_expander.get_main_outputs()
-    _parent_expander.require_idx_states(IdxType.Atoms)
 
     def __init__(self, name, parents, module="auto", _helper=None, **kwargs):
         parents = self.expand_parents(parents)


### PR DESCRIPTION
This was causing lammps interfaces not to build correctly.