### PR TITLE
Switch git clone url from ssh to https in docs

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -45,7 +45,7 @@ Installation Instructions
 
 Clone the hippynn_ repository and navigate into it, e.g.::
 
-    $ git clone git@github.com:lanl/hippynn.git
+    $ git clone https://github.com/lanl/hippynn.git
     $ cd hippynn
 
 .. _hippynn: https://github.com/lanl/hippynn/


### PR DESCRIPTION
I just noticed this problem today when helping a student to set up hippynn.

For people who haven't set up SSH keys in the github account, the ssh url won't work. 