### PR TITLE
Updated Cusp Regularization

### DIFF
--- a/hippynn/experiment/serialization.py
+++ b/hippynn/experiment/serialization.py
@@ -15,8 +15,6 @@ from .assembly import TrainingModules
 from .controllers import PatienceController
 from .device import set_devices
 from .metric_tracker import MetricTracker
-from ..networks.hipnn import HipnnVec
-from ..layers.transform import ResNetWrapper
 
 DEFAULT_STRUCTURE_FNAME = "experiment_structure.pt"
 

--- a/hippynn/experiment/serialization.py
+++ b/hippynn/experiment/serialization.py
@@ -149,8 +149,6 @@ def load_checkpoint(
 
     # transfer stuff back to model_device
     structure = restore_checkpoint(structure, state, restore_db=restore_db)
-    # Apply backwards compatibility for model.
-    backward_compatibility(structure["training_modules"].model)
     # no transfer happens in either case, as the tensors are on the target devices already
     if model_device == "cpu" or map_location != None:
         evaluator = structure["training_modules"].evaluator
@@ -162,7 +160,6 @@ def load_checkpoint(
         optimizer = structure["controller"].optimizer
         model, loss, evaluator = training_modules
         model, evaluator, optimizer = set_devices(model, loss, evaluator, optimizer, model_device)
-        model = backward_compatibility(model)
     # if neither map_location nor model_device is set, directly return
     return structure
 
@@ -200,40 +197,8 @@ def load_model_from_cwd(map_location=None, model_device=None, **kwargs) -> Graph
 
     model = structure["training_modules"].model
     model.load_state_dict(state)
-    backward_compatibility(model)
     if map_location == None and model_device != None and model_device != "cpu":
         model = model.to(model_device)
 
     return model
 
-
-def backward_compatibility(model):
-    """ Mutates model graph in place to incorporate new attributes to ensure that
-    older hipnn models run with current code. 
-
-    Note that this function is subject to frequent changes depending on which 
-    older versions of hippynn are still supported.
-
-    :param model: hipnn model. 
-    :type model: GraphModule
-    """
-    # add `cusp_reg` to older models trained with default values. 
-    DEPRECATED_CUSP_REG = 1e-30
-    for k, v in model._modules["moddict"].items():
-        if isinstance(v, (HipnnVec,)): 
-            if "cusp_reg" in vars(v):
-                pass
-            else:
-                warnings.warn(
-                    "Deprecated: Hipnn model trained with outdated cusp-regularization", 
-                    # PendingDeprecationWarning
-                )
-                # Set cusp regularization for HipnnQuad or HipnnVec 
-                model._modules["moddict"][k].cusp_reg = DEPRECATED_CUSP_REG
-                
-                # Set cusp regularization for interaction layers
-                for l in model._modules["moddict"][k].interaction_layers:
-                    if isinstance(l, (ResNetWrapper,)):
-                        l.base_layer.cusp_reg = DEPRECATED_CUSP_REG
-                    else:
-                        l.cusp_reg = DEPRECATED_CUSP_REG

--- a/hippynn/layers/hiplayers.py
+++ b/hippynn/layers/hiplayers.py
@@ -139,7 +139,7 @@ class InteractLayer(torch.nn.Module):
     Hipnn's interaction layer
     """
 
-    def __init__(self, nf_in, nf_out, n_dist, mind_soft, maxd_soft, hard_cutoff, sensitivity_module):
+    def __init__(self, nf_in, nf_out, n_dist, mind_soft, maxd_soft, hard_cutoff, sensitivity_module, cusp_reg):
         """
         Constructor
 
@@ -150,6 +150,7 @@ class InteractLayer(torch.nn.Module):
         :param maxd_soft: maximum distance for initial sensitivities
         :param hard_cutoff: maximum distance for cutoff function
         :param sensitivity_module: class or callable that builds sensitivity functions, should return nn.Module
+        :param cusp_reg: 
         """
         super().__init__()
 

--- a/hippynn/layers/hiplayers.py
+++ b/hippynn/layers/hiplayers.py
@@ -213,7 +213,7 @@ class InteractLayer(torch.nn.Module):
 
 class InteractLayerVec(InteractLayer):
     def __init__(self, nf_in, nf_out, n_dist, mind_soft, maxd_soft, hard_cutoff, sensitivity_module, cusp_reg):
-        super().__init__(nf_in, nf_out, n_dist, mind_soft, maxd_soft, hard_cutoff, sensitivity_module)
+        super().__init__(nf_in, nf_out, n_dist, mind_soft, maxd_soft, hard_cutoff, sensitivity_module, cusp_reg)
         self.vecscales = torch.nn.Parameter(torch.Tensor(nf_out))
         torch.nn.init.normal_(self.vecscales.data)
         self.cusp_reg = cusp_reg

--- a/hippynn/layers/hiplayers.py
+++ b/hippynn/layers/hiplayers.py
@@ -235,7 +235,7 @@ class InteractLayerVec(InteractLayer):
         env_features_vec = env_features_vec.reshape(n_atoms_real * 3, self.n_dist * self.nf_in)
         features_out_vec = torch.mm(env_features_vec, weights_rs)
         features_out_vec = features_out_vec.reshape(n_atoms_real, 3, self.nf_out)
-        features_out_vec = torch.square(features_out_vec).sum(dim=1) + 1e-30
+        features_out_vec = torch.square(features_out_vec).sum(dim=1) + 1e-6
         features_out_vec = torch.sqrt(features_out_vec)
         features_out_vec = features_out_vec * self.vecscales.unsqueeze(0)
 
@@ -280,7 +280,7 @@ class InteractLayerQuad(InteractLayerVec):
         features_out_vec = torch.mm(env_features_vec, weights_rs)
         # Norm and scale
         features_out_vec = features_out_vec.reshape(n_atoms_real, 3, self.nf_out)
-        features_out_vec = torch.square(features_out_vec).sum(dim=1) + 1e-30
+        features_out_vec = torch.square(features_out_vec).sum(dim=1) + 1e-6
         features_out_vec = torch.sqrt(features_out_vec)
         features_out_vec = features_out_vec * self.vecscales.unsqueeze(0)
 
@@ -303,7 +303,7 @@ class InteractLayerQuad(InteractLayerVec):
         quadfirst = torch.square(features_out_quad).sum(dim=1)
         quadsecond = features_out_quad[:, 0, :] * features_out_quad[:, 3, :]
         features_out_quad = 2 * (quadfirst + quadsecond)
-        features_out_quad = torch.sqrt(features_out_quad + 1e-30)
+        features_out_quad = torch.sqrt(features_out_quad + 1e-6)
         # Scales
         features_out_quad = features_out_quad * self.quadscales.unsqueeze(0)
 

--- a/hippynn/layers/hiplayers.py
+++ b/hippynn/layers/hiplayers.py
@@ -16,7 +16,7 @@ def warn_if_under(distance, threshold):
     if dmin < threshold:
         d_count = distance < threshold
         d_frac = d_count.to(distance.dtype).mean()
-        d_sum = (d_count.sum()/2).to(torch.int)
+        d_sum = (d_count.sum() / 2).to(torch.int)
         warnings.warn(
             "Provided distances are underneath sensitivity range!\n"
             f"Minimum distance in current batch: {dmin}\n"
@@ -221,19 +221,20 @@ class InteractLayerVec(InteractLayer):
         torch.nn.init.normal_(self.vecscales.data)
         self.cusp_reg = cusp_reg
 
-
     def __setstate__(self, state):
         output = super().__setstate__(state)
         if not hasattr(self, "cusp_reg"):
             # The layer was created before the cusp regularization was a parameter.
             # Add a patch that if a state dict is loaded in with no cusp parameter,
             # use the pre-introduction static value.
-            warnings.warn("Loading a module which does not contain the 'cusp_reg' parameter. "
-                          "In the future, this behavior will cause an error. "
-                          "To avoid this warning, re-save this model to disk. "
-                          )
+            warnings.warn(
+                "Loading a module which does not contain the 'cusp_reg' parameter. "
+                "In the future, this behavior will cause an error. "
+                "To avoid this warning, re-save this model to disk. "
+            )
             self.handle = self.register_load_state_dict_post_hook(self.compatibility_hook)
         return output
+
     @staticmethod
     def compatibility_hook(self, incompatible_keys):
         missing = incompatible_keys.missing_keys
@@ -246,19 +247,20 @@ class InteractLayerVec(InteractLayer):
             return
 
         for m in missing:
-            if m.endswith('_extra_state'):
+            if m.endswith("_extra_state"):
                 break
         else:
             # Python reminder: The mysterious "else" clause of the for loop
             # activates when python does not break out of the for loop.
-            return # No _extra_state type variable was missing: just return.
+            return  # No _extra_state type variable was missing: just return.
 
         DEPRECATED_CUSP_REG = 1e-30
-        warnings.warn(f"Loaded state does not contain 'cusp_reg' parameter. "
-                      f"Using deprecated value of 1e-30. "
-                      f"This compatibility behavior will be removed in the future. "
-                      f"To avoid this warning, re-save this model."
-                      )
+        warnings.warn(
+            f"Loaded state does not contain 'cusp_reg' parameter. "
+            f"Using deprecated value of 1e-30. "
+            f"This compatibility behavior will be removed in the future. "
+            f"To avoid this warning, re-save this model."
+        )
         self.set_extra_state({"cusp_reg": DEPRECATED_CUSP_REG})
         missing.remove(m)
 
@@ -266,7 +268,7 @@ class InteractLayerVec(InteractLayer):
         return {"cusp_reg": self.cusp_reg}
 
     def set_extra_state(self, state):
-        self.cusp_reg = state['cusp_reg']
+        self.cusp_reg = state["cusp_reg"]
 
     def forward(self, in_features, pair_first, pair_second, dist_pairs, coord_pairs):
 
@@ -360,5 +362,5 @@ class InteractLayerQuad(InteractLayerVec):
         features_out_selfpart = self.selfint(in_features)
 
         features_out_total = features_out + features_out_vec + features_out_quad + features_out_selfpart
-        
+
         return features_out_total

--- a/hippynn/networks/hipnn.py
+++ b/hippynn/networks/hipnn.py
@@ -245,7 +245,9 @@ class HipnnVec(Hipnn):
     """
     HIP-NN-TS with l=1
     """
+
     _interaction_class = InteractLayerVec
+
     def __init__(self, *args, cusp_reg=1e-6, **kwargs):
         # cusp regularization for tensor sensitivity l>0. Defaults to 1e-6.
         super().__init__(*args, cusp_reg=cusp_reg, **kwargs)

--- a/hippynn/networks/hipnn.py
+++ b/hippynn/networks/hipnn.py
@@ -80,7 +80,7 @@ class Hipnn(torch.nn.Module):
         sensitivity_type="inverse",
         resnet=True,
         activation=torch.nn.Softplus,
-        cusp_reg=1e-6,
+        cusp_reg=None,
     ):
         """
 
@@ -98,7 +98,7 @@ class Hipnn(torch.nn.Module):
            'inverse' is what is in hip-nn original paper.
         :param resnet: bool or int, if int, size of internal resnet width
         :param activation: activation function or subclass of nn.module.
-        :param cusp_reg: cusp regularization for tensor sensitivity l>0. Defaults to 1e-6. 
+        :param cusp_reg: Used for API compatibility, but ignored in vanilla HIP-NN.
 
         Note: only one of possible_species or n_input_features is needed. If both are supplied,
         they must be consistent with each other.
@@ -179,7 +179,6 @@ class Hipnn(torch.nn.Module):
             this_block = torch.nn.ModuleList()
 
             # Add interaction layer
-            self.cusp_reg = cusp_reg
             lay = self._interaction_class(
                 in_size, middle_size, n_sensitivities, dist_soft_min, dist_soft_max, dist_hard_max, sensitivity_type, cusp_reg
             )
@@ -246,8 +245,10 @@ class HipnnVec(Hipnn):
     """
     HIP-NN-TS with l=1
     """
-
     _interaction_class = InteractLayerVec
+    def __init__(self, *args, cusp_reg=1e-6, **kwargs):
+        # cusp regularization for tensor sensitivity l>0. Defaults to 1e-6.
+        super().__init__(*args, cusp_reg=cusp_reg, **kwargs)
 
     def forward(self, features, pair_first, pair_second, pair_dist, pair_coord):
         features = features.to(pair_dist.dtype)  # Convert one-hot features to floating point features.

--- a/hippynn/networks/hipnn.py
+++ b/hippynn/networks/hipnn.py
@@ -80,6 +80,7 @@ class Hipnn(torch.nn.Module):
         sensitivity_type="inverse",
         resnet=True,
         activation=torch.nn.Softplus,
+        cusp_reg=1e-6,
     ):
         """
 
@@ -97,6 +98,7 @@ class Hipnn(torch.nn.Module):
            'inverse' is what is in hip-nn original paper.
         :param resnet: bool or int, if int, size of internal resnet width
         :param activation: activation function or subclass of nn.module.
+        :param cusp_reg: cusp regularization for tensor sensitivity l>0. Defaults to 1e-6. 
 
         Note: only one of possible_species or n_input_features is needed. If both are supplied,
         they must be consistent with each other.
@@ -177,8 +179,9 @@ class Hipnn(torch.nn.Module):
             this_block = torch.nn.ModuleList()
 
             # Add interaction layer
+            self.cusp_reg = cusp_reg
             lay = self._interaction_class(
-                in_size, middle_size, n_sensitivities, dist_soft_min, dist_soft_max, dist_hard_max, sensitivity_type
+                in_size, middle_size, n_sensitivities, dist_soft_min, dist_soft_max, dist_hard_max, sensitivity_type, cusp_reg
             )
             if self.resnet:
                 lay = ResNetWrapper(lay, in_size, middle_size, out_size, self.activation)


### PR DESCRIPTION
The regularization term for the hipnnvec and hipnnquad are increased to `1e-6`.
The original regularization was too small, leading to unexpected force predictions. 

In a separate Pull Request, we can update the interface so that this regularization value can be set by the user at training time. 
