### PR TITLE
Added variable to limit pytorch memory in lammps interface

### DIFF
--- a/docs/source/user_guide/settings.rst
+++ b/docs/source/user_guide/settings.rst
@@ -64,3 +64,8 @@ The following settings are available:
      - true, false
      - false
      - no
+   * - PYTORCH_GPU_MEM_FRAC
+     - In the Lammps interface, limit the amount of memory used by pytorch. Setting this value below 1.0 can force pytorch to garbage collect before entirely depleating GPU memory, leaving room for Lammps/KOKKOS. Leaving this variable unset imposes no pytorch memory limit
+     - float between 0 and 1
+     - 1.0
+     - no

--- a/hippynn/_settings_setup.py
+++ b/hippynn/_settings_setup.py
@@ -73,6 +73,7 @@ default_settings = {
     "USE_CUSTOM_KERNELS": ("auto", kernel_handler),
     "WARN_LOW_DISTANCES": (True, strtobool),
     "TIMEPLOT_AUTOSCALING": (True, strtobool),
+    "PYTORCH_GPU_MEM_FRAC": (1.0, float),
 }
 
 settings = SimpleNamespace(**{k: default for k, (default, handler) in default_settings.items()})

--- a/hippynn/interfaces/lammps_interface/mliap_interface.py
+++ b/hippynn/interfaces/lammps_interface/mliap_interface.py
@@ -3,7 +3,6 @@ Interface for creating LAMMPS MLIAP Unified models.
 """
 import pickle
 import warnings
-from os import environ
 
 import numpy as np
 import torch
@@ -36,8 +35,8 @@ class MLIAPInterface(MLIAPUnified):
         :param model_device: the device to send torch data to (cpu or cuda)
         """
         super().__init__()
-        if environ("HIPPYNN_PYTORCH_GPU_MEM_FRAC") is not None:
-            torch.cuda.set_per_process_memory_fraction(float(environ("HIPPYNN_PYTORCH_GPU_MEM_FRAC")))
+        if hippynn.settings.PYTORCH_GPU_MEM_FRAC < 1.0:
+            torch.cuda.set_per_process_memory_fraction(hippynn.settings.PYTORCH_GPU_MEM_FRAC)
         self.element_types = element_types
         self.ndescriptors = ndescriptors
         self.model_device = model_device

--- a/hippynn/interfaces/lammps_interface/mliap_interface.py
+++ b/hippynn/interfaces/lammps_interface/mliap_interface.py
@@ -3,6 +3,7 @@ Interface for creating LAMMPS MLIAP Unified models.
 """
 import pickle
 import warnings
+from os import environ
 
 import numpy as np
 import torch
@@ -35,6 +36,8 @@ class MLIAPInterface(MLIAPUnified):
         :param model_device: the device to send torch data to (cpu or cuda)
         """
         super().__init__()
+        if environ("HIPPYNN_PYTORCH_GPU_MEM_FRAC") is not None:
+            torch.cuda.set_per_process_memory_fraction(float(environ("HIPPYNN_PYTORCH_GPU_MEM_FRAC")))
         self.element_types = element_types
         self.ndescriptors = ndescriptors
         self.model_device = model_device

--- a/hippynn/tools.py
+++ b/hippynn/tools.py
@@ -120,6 +120,7 @@ def param_print(module):
 def device_fallback():
     device = (torch.cuda.is_available() and torch.device(torch.cuda.current_device())) or torch.device("cpu")
     print("Device was not specified. Attempting to default to device:", device)
+    device = torch.device(device.type)
     return device
 
 


### PR DESCRIPTION
Added setting PYTORCH_GPU_MEM_FRAC that will set the call torch.cuda.set_per_process_memory_fraction in the lammps interface. Helps prevent out of memory errors when running with kokkos. Added documentation for new setting. 