### PR TITLE
Check cuda device capability for triton kernel initialization.

### DIFF
--- a/hippynn/custom_kernels/__init__.py
+++ b/hippynn/custom_kernels/__init__.py
@@ -42,7 +42,7 @@ try:
         CUSTOM_KERNELS_AVAILABLE.append("triton")
     else:
         warnings.warn(
-            f"Triton found but not supported by GPU's compute capability: {torch.cuda.get_device_capability()}"
+            f"Triton found but not supported by GPU's compute capability: {device_capbility}"
         )
 except ImportError:
     pass

--- a/hippynn/custom_kernels/__init__.py
+++ b/hippynn/custom_kernels/__init__.py
@@ -37,12 +37,12 @@ except ImportError:
 try:
     import triton
     import torch 
-    device_capbility = torch.cuda.get_device_capability()
-    if device_capbility[0] > 6:
+    device_capability = torch.cuda.get_device_capability()
+    if device_capability[0] > 6:
         CUSTOM_KERNELS_AVAILABLE.append("triton")
     else:
         warnings.warn(
-            f"Triton found but not supported by GPU's compute capability: {device_capbility}"
+            f"Triton found but not supported by GPU's compute capability: {device_capability}"
         )
 except ImportError:
     pass

--- a/hippynn/custom_kernels/__init__.py
+++ b/hippynn/custom_kernels/__init__.py
@@ -35,21 +35,18 @@ except ImportError:
     pass
 
 try:
+    import triton
     import torch 
-    if torch.cuda.get_device_capability()[0]>6:
-        try:
-            import triton
-            CUSTOM_KERNELS_AVAILABLE.append("triton")
-        except ImportError:
-            pass
-    else: 
-        try:
-            import triton
-            warnings.warn(
-                f"Triton found but not supported by GPU's compute capability: {torch.cuda.get_device_capability()}"
-            )
-        except ImportError:
-            pass
+    device_capbility = torch.cuda.get_device_capability()
+    if device_capbility[0] > 6:
+        CUSTOM_KERNELS_AVAILABLE.append("triton")
+    else:
+        warnings.warn(
+            f"Triton found but not supported by GPU's compute capability: {torch.cuda.get_device_capability()}"
+        )
+except ImportError:
+    pass
+
         
 except ImportError:
     pass

--- a/hippynn/custom_kernels/__init__.py
+++ b/hippynn/custom_kernels/__init__.py
@@ -35,9 +35,22 @@ except ImportError:
     pass
 
 try:
-    import triton
-
-    CUSTOM_KERNELS_AVAILABLE.append("triton")
+    import torch 
+    if torch.cuda.get_device_capability()[0]>6:
+        try:
+            import triton
+            CUSTOM_KERNELS_AVAILABLE.append("triton")
+        except ImportError:
+            pass
+    else: 
+        try:
+            import triton
+            warnings.warn(
+                f"Triton found but not supported by GPU's compute capability: {torch.cuda.get_device_capability()}"
+            )
+        except ImportError:
+            pass
+        
 except ImportError:
     pass
 
@@ -76,7 +89,7 @@ def _check_cupy():
     if not cupy.cuda.is_available():
         if torch.cuda.is_available():
             warnings.warn("cupy.cuda.is_available() returned False: Custom kernels will fail on GPU tensors.")
-
+    
 
 def set_custom_kernels(active: Union[bool, str] = True):
     """
@@ -113,7 +126,6 @@ def set_custom_kernels(active: Union[bool, str] = True):
         return
 
     # Select custom kernel implementation
-
     if not CUSTOM_KERNELS_AVAILABLE:
         raise RuntimeError("Numba was not found. Custom kernels are not available.")
 


### PR DESCRIPTION
The triton custom kernel fails for cuda device capability 6 or lower. 
Additional checks to ensure cuda `device_capability` is greater than 6 when checking for `triton`. 