### PR TITLE
Add atomization-consistent training

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Breaking changes:
   functions are ``load_checkpoint``, ``load_checkpoint_from_cwd``, and
   ``restore_checkpoint``.
 - ``database.make_trainvalidtest_split`` now only takes keyword arguments to
-  avoid confusions. Use ``make_trainvalidtest_split(test_size=a, valid_size=b)``
+  avoid confusion. Use ``make_trainvalidtest_split(test_size=a, valid_size=b)``
   instead of ``make_trainvalidtest_split(a, b)``.
 - Invalid custom kernel specifications are now errors rather than warnings.
 - Method of specifying units for custom MD algorithms has changed.
@@ -31,6 +31,7 @@ New Features:
   are compatible with molecular dynamics codes such ASE and LAMMPS.
 - Added the ability to weight different systems/atoms/bonds in a loss function.
 - Added new function to reload library settings.
+- Added atomization-consistent node which exactly constrains their predictions in a dissociated limit.
 
 
 Improvements:
@@ -47,6 +48,7 @@ Improvements:
 - Improved detection of valid custom kernel implementation.
 - Improved computational efficiency of HIP-NN-TS network.
 - ``StressForceNode`` now also works with batch size greater than 1.
+- Allow testing of splits of arbitrary names using test_model, as long as those splits contain the required variables.
 
 
 Bug Fixes:

--- a/docs/source/examples/ase_calculator.rst
+++ b/docs/source/examples/ase_calculator.rst
@@ -3,7 +3,8 @@ ASE Calculators
 
 Hippynn models can be used with ``ase`` to perform molecular dynamics or other tests.
 
-To build an ASE calculator, you must pass the node associated with energy.
+To build an ASE calculator, use the :class:`~hippynn.interfaces.ase_interface.HippynnCalculator` object.
+You pass the node associated with energy.
 Example::
 
     from hippynn.interfaces.ase_interface import HippynnCalculator
@@ -13,11 +14,16 @@ Example::
 
 Take note of the ``en_unit`` and ``dist_unit`` parameters for the calculator.
 These parameters inform the calculator what units the model consumes and produces for energy and
-for distance. If unspecified, the ``en_unit`` is kcal/mol, and the ``dist_unit`` is angstrom.
-Whatever units your model uses, the output of the calculator will be in the ``ase`` unit system,
-which has energy in eV and distance in Angstroms.
+for distance. If unspecified, the ``en_unit`` is kcal/mol (different from ase default of eV!),
+and the ``dist_unit`` is angstrom. Whatever units your model uses, the output of the calculator
+will be in the ``ase`` unit system, which has energy in eV and distance in Angstroms.
 
-Given an ase atoms object, one can assign the calculator::
+If your model only contains one energy node, you can use the function
+:func:`~hippynn.interfaces.ase_interface.calculator_from_model`, which automatically identifies
+the energy node and from this creates the calculator. This function accepts keyword arguments that will
+be passed to the calculator.
+
+Given an ase ``atoms`` object, one can assign the calculator::
 
     atoms.calc = calc
 

--- a/docs/source/user_guide/databases.rst
+++ b/docs/source/user_guide/databases.rst
@@ -24,11 +24,11 @@ Note that input of bond variables for periodic systems can be ill-defined
 if there are multiple bonds between the same pairs of atoms. This is not yet
 supported.
 
-A note on *cell* variables. The shape of a cell variable should be specified as (n_atoms,3,3).
-There are two common conventions for the cell matrix itself; we use the convention that the basis index
-comes first, and the cartesian index comes second. That is similar to `ase`,
-the [i,j] element of the cell gives the j cartesian coordinate of cell vector i. If you experience
-massive difficulties fitting to periodic boundary conditions, you may check the transposed version
+A note on *cell* variables. The shape of a cell variable should be specified as (n_systems,3,3), as described above.
+It is important to know that there are two common conventions for the cell matrix itself; we use the convention that the basis index
+comes first, and the cartesian index comes second. That is, similar to the ``ase`` package,
+the element ``cell[sys,i,j]`` gives the ``j`` cartesian coordinate of cell vector ``i`` in system ``sys``. If you experience
+massive errors while fitting to periodic boundary conditions, you may check the transposed version
 of your cell data, or compute the RDF.
 
 Database Formats and notes

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,29 @@
+Example files for HIPPYNN 
+-------------------------
+
+The files in this directory provide examples for hippynn.
+Because hippynn is for training and running machine learning models,
+it requires data to run! Our example files typically contain
+a header which describes where to get the data in order to run the example.
+Occasionally an example file for running a model depends on running a
+different example for training that model.
+
+
+Suggested Starting Points
+-------------------------
+
+- If you're looking to get a basic picture of how hippynn works, see
+``barebones.py``, which is about as simple of an example as can function.
+If you have a basic understanding but want to see more details,
+check out the jupyter notebooks ``graph_exploration.ipynb``.
+
+- If you're looking to customize a nicely constructed training script,
+ look into ``ani1x_training.py``. This trains to a large dataset
+ known as ani1x, and separates out the various aspects of the 
+ library as well as demonstrating how they interact together.
+ It has many optional features included. 
+
+- If you want to see how to use a model with ase or lammps,
+first train a model with ``ani_aluminum_example.py``. 
+Then check out ``ase_example.py`` or the ``examples/lammps/``
+directory respectively.

--- a/examples/ani1x_training.py
+++ b/examples/ani1x_training.py
@@ -233,11 +233,15 @@ def main(args):
 
             hierarchical_energy_initialization(henergy, database, trainable_after=False)
 
+            patience = args.patience
+            if args.use_ccx_subset:
+                patience *= 4
+
             setup_params = setup_experiment(training_modules,
                                             device=args.gpu,
                                             batch_size=args.batch_size,
                                             init_lr=args.init_lr,
-                                            patience=args.patience,
+                                            patience=patience,
                                             max_epochs=args.max_epochs,
                                             stopping_key=args.stopping_key,
                                             )
@@ -273,7 +277,7 @@ if __name__ == "__main__":
     parser.add_argument("--qm_method", type=str, default='wb97x')
     parser.add_argument("--basis_set", type=str, default='dz')
 
-    parser.add_argument("--force_training", action='store_true', default=False)
+    parser.add_argument("--force_training", action='store_true', default=True)
 
     parser.add_argument("--batch_size",type=int, default=256)
     parser.add_argument("--init_lr",type=float, default=1e-3)
@@ -282,8 +286,9 @@ if __name__ == "__main__":
     parser.add_argument("--stopping_key",type=str, default="T-RMSE")
 
     parser.add_argument("--use_ccx_subset",type=bool, default=False,
-                        help="Train only to configurations for the ANI-1ccx dataset."
-                             " Note that this will still use the energies using the `qm_method` argument.")
+                        help="Train only to configurations from the ANI-1ccx subset."
+                             " Note that this will still use the energies using the `qm_method` argument."
+                             " *Note!* This argument will multiply the patience by a factor of 4.")
 
 
     parser.add_argument("--noprogress", action='store_true', default=False, help='suppress progress bars')

--- a/examples/ani1x_training.py
+++ b/examples/ani1x_training.py
@@ -261,7 +261,7 @@ if __name__ == "__main__":
 
     parser.add_argument("--n_interactions", type=int, default=2)
     parser.add_argument("--n_atom_layers", type=int, default=3)
-    parser.add_argument("--n_features", type=int, default=20)
+    parser.add_argument("--n_features", type=int, default=128)
     parser.add_argument("--n_sensitivities", type=int, default=20)
     parser.add_argument("--cutoff_distance", type=float, default=6.5)
     parser.add_argument("--lower_cutoff",type=float,default=0.75,
@@ -275,7 +275,7 @@ if __name__ == "__main__":
 
     parser.add_argument("--force_training", action='store_true', default=False)
 
-    parser.add_argument("--batch_size",type=int, default=1024)
+    parser.add_argument("--batch_size",type=int, default=256)
     parser.add_argument("--init_lr",type=float, default=1e-3)
     parser.add_argument("--patience",type=int, default=5)
     parser.add_argument("--max_epochs",type=int, default=500)

--- a/examples/ani1x_training.py
+++ b/examples/ani1x_training.py
@@ -115,7 +115,6 @@ def load_db(db_info, en_name, force_name, seed, anidata_location, n_workers):
     # Drop indices where computed energy not retrieved.
     found_indices = ~np.isnan(database.arr_dict[en_name])
     database.arr_dict = {k: v[found_indices] for k, v in database.arr_dict.items()}
-    database.make_random_split("delete",size=0.99999); del database.splits['delete']
     database.make_trainvalidtest_split(test_size=0.1, valid_size=0.1)
     return database
 

--- a/hippynn/__init__.py
+++ b/hippynn/__init__.py
@@ -12,7 +12,6 @@ The hippynn python package.
 from . import _version
 __version__ = _version.get_versions()['version']
 
-
 # Configuration settings
 from ._settings_setup import settings, reload_settings
 
@@ -30,7 +29,14 @@ from . import networks
 
 # Graph abstractions
 from . import graphs
-from .graphs import nodes, IdxType, GraphModule, Predictor
+from .graphs import nodes, IdxType, GraphModule, Predictor, make_ensemble
+
+# Kinds of nodes
+from .graphs.nodes import inputs, targets, loss, pairs, physics, indexers, pairs
+from .graphs.nodes import networks as network_nodes
+
+from . import pretraining
+from .pretraining import hierarchical_energy_initialization
 
 # Database loading
 from . import databases
@@ -55,9 +61,25 @@ else:
     del ase
     from . import molecular_dynamics
     from . import optimizer
+    from .interfaces import ase_interface
 
-from . import pretraining
-from .pretraining import hierarchical_energy_initialization
+# Submodules that require pyseqm
+try:
+    import seqm
+except ImportError:
+    pass
+else:
+    del seqm
+    from .interfaces import pyseqm_interface
+
+# Submodules that require lammps
+try:
+    import lammps
+except ImportError:
+    pass
+else:
+    del lammps
+    from .interfaces import lammps_interface
 
 # The order is adjusted to put functions after objects in the documentation.
 _dir = dir()

--- a/hippynn/__init__.py
+++ b/hippynn/__init__.py
@@ -79,7 +79,12 @@ except ImportError:
     pass
 else:
     del lammps
-    from .interfaces import lammps_interface
+    try:
+        from .interfaces import lammps_interface
+    except Exception as eee:
+        import warnings
+        warnings.warn(f"Lammps interface was not importable due to exception: :{eee}")
+        del eee, warnings
 
 # The order is adjusted to put functions after objects in the documentation.
 _dir = dir()

--- a/hippynn/custom_kernels/__init__.py
+++ b/hippynn/custom_kernels/__init__.py
@@ -127,7 +127,7 @@ def set_custom_kernels(active: Union[bool, str] = True) -> str:
         active = active.lower()
 
     if active not in _POSSIBLE_CUSTOM_KERNELS:
-        raise warnings.warn(f"Using non-standard custom kernel implementation: {active}")
+        warnings.warn(f"Using non-standard custom kernel implementation: {active}")
 
     # Our goal is that this if-block is to handle the cases for values in the range of
     # [True, "auto"] and turn them into the suitable actual implementation.

--- a/hippynn/databases/database.py
+++ b/hippynn/databases/database.py
@@ -280,7 +280,7 @@ class Database:
         :param split_mask: a boolean array for where to split
         :return:
         """
-        if isinstance(split_mask, torch.tensor):
+        if isinstance(split_mask, torch.Tensor):
             split_mask = split_mask.numpy()
         if split_mask.dtype != np.bool_:
             if not np.isin(split_mask, [0, 1]).all():

--- a/hippynn/graphs/nodes/base/algebra.py
+++ b/hippynn/graphs/nodes/base/algebra.py
@@ -78,13 +78,14 @@ class _CombNode(_BaseNode):
 class ValueNode(_CombNode):
     _index_state = IdxType.Scalar
 
-    def __init__(self, value):
+    def __init__(self, value, convert=True):
         name = "Value({})".format(str(value))
         self.value = value
+        self._converted = convert
         super().__init__(name, parents=(), module="auto")
 
     def auto_module(self):
-        return algebra_mods.ValueMod(self.value)
+        return algebra_mods.ValueMod(self.value, convert=self._converted)
 
 
 class _PredefinedOp:

--- a/hippynn/graphs/nodes/targets.py
+++ b/hippynn/graphs/nodes/targets.py
@@ -2,8 +2,10 @@
 Nodes for prediction of variables from network features.
 """
 
+import torch
+
 from .base import MultiNode, AutoKw, ExpandParents, find_unique_relative, _BaseNode
-from .tags import AtomIndexer, Network, PairIndexer, HAtomRegressor, Charges, Energies
+from .tags import AtomIndexer, Network, PairIndexer, HAtomRegressor, Charges, Energies, Encoder
 from .indexers import PaddingIndexer
 from ..indextypes import IdxType, index_type_coercion
 from ...layers import targets as target_modules
@@ -28,6 +30,16 @@ class HEnergyNode(Energies, HAtomRegressor, AutoKw, ExpandParents, MultiNode):
         return net, pdindexer.mol_index, pdindexer.n_molecules
 
     def __init__(self, name, parents, first_is_interacting=False, module="auto", module_kwargs=None, **kwargs):
+        """
+
+        :param name:
+        :param parents:
+        :param first_is_interacting: If True, drop the first feature
+         components (which do not interact and so are based only on initial features for the atom)
+        :param module:
+        :param module_kwargs: other module keywords to use in initialization.
+        :param kwargs:
+        """
         self.module_kwargs = {"first_is_interacting": first_is_interacting}
         if module_kwargs is not None:
             self.module_kwargs = {**self.module_kwargs, **module_kwargs}
@@ -102,3 +114,97 @@ class HBondNode(ExpandParents, AutoKw, MultiNode):
         super().__init__(name, parents, module=module, **kwargs)
 
 
+class AtomizationEnergyNode(Energies, HAtomRegressor, AutoKw, ExpandParents, MultiNode):
+    _input_names = "hier_features", "vac_features", "encoding", "mol_index", "n_molecules"
+    _output_names = "mol_energy", "partial_energies", "hierarchicality"
+    _output_index_states = IdxType.Molecules, None, IdxType.Molecules
+    _main_output = "mol_energy"
+    _auto_module_class = target_modules.AtomizationEnergy
+
+    @_parent_expander.match(Network)
+    def expansion1(self, net, **kwargs):
+        from ..gops import vacuum_outputs
+        encoder = find_unique_relative(net, Encoder)
+        if "feature_sizes" not in self.module_kwargs:
+            self.module_kwargs["feature_sizes"] = net.torch_module.feature_sizes
+        pdindexer = find_unique_relative(net, AtomIndexer)
+        species_set = net.torch_module.species_set[1:]
+        vac_net, = vacuum_outputs([net], species_set=species_set)
+        return net, vac_net, encoder, pdindexer
+
+    @_parent_expander.match(Network, Network, Encoder, AtomIndexer)
+    def expansion0(self, net, vacuum_net, encoding, pdindexer, **kwargs):
+        # Used to be built explicitly because of introduction of multiple encoders.
+        # Now fixed by using constants when encoding on the vacuum side.
+        # encatom = AtomReIndexer('Encoding[atoms]', (encoding.encoding, pdindexer))
+        return net, vacuum_net, encoding.encoding, pdindexer.mol_index, pdindexer.n_molecules,
+
+    _parent_expander.assertlen(5)
+    _parent_expander.get_main_outputs()
+    _parent_expander.require_idx_states(None, None, IdxType.Atoms, None, None)
+
+    def __init__(self, name, parents, module='auto', module_kwargs=None, **kwargs):
+        self.module_kwargs = {**module_kwargs} if module_kwargs else {}
+
+        parents = self.expand_parents(parents, **kwargs)
+        super().__init__(name, parents, module=module, **kwargs)
+
+    def create_henergy_equivalent(self):
+        from .. import copy_subgraph, Predictor
+
+        # ignore vacuum encoding input
+        net_parent, vac_net, _, mol_index, n_molecules = self.parents
+        new_parents = (net_parent, mol_index, n_molecules)
+
+        # copy-out subgraph for vacuum computations.
+        new_graph, other_nodes = copy_subgraph(vac_net.feature_nodes, assume_inputed=[])
+
+        # # This builds the graph for de-indexing atom to molatom,
+        # # without having a paddingindexer.
+        # # Leaving this as reference in case it becomes necessary to do this later.
+        # from .base.algebra import ValueNode
+        # from .indexers import AtomDeIndexer
+        # species_set = vac_net.torch_module.species_set
+        # n_atom_types = len(species_set)-1
+        # mol_index = ValueNode(torch.arange(n_atom_types, dtype=torch.int64, device=species_set.device))
+        # atom_index = ValueNode(torch.zeros(n_atom_types, dtype=torch.int64, device=species_set.device))
+        # n_molecules = ValueNode(n_atom_types, convert=False)
+        # n_atoms_max = ValueNode(1, convert=False)
+        # from ..indextypes.registry import assign_index_aliases
+        # for n in new_graph:
+        #     index_node = AtomDeIndexer(f"{n.name}[MolAtom]", (n, mol_index, atom_index, n_molecules, n_atoms_max))
+        #     assign_index_aliases(n, index_node)
+
+        # Alternative hacky way to solve the problem is much simpler.
+        for n in new_graph:
+            n._index_state = IdxType.MolAtom
+
+        pred = Predictor(inputs=[], outputs=new_graph)
+        outputs = pred()
+
+        # Note that atomization ignores the first (raw vacuum) features of the network.
+        # Note that we squeeze because each system has 1 atom.
+        feature_list = [outputs[n.name].squeeze(1) for n in new_graph[1:]]
+        weights = [x.weight for x in self.torch_module.layers]
+
+        # Calculate the total bias terms per species.
+        en_contributions = [w @ x.T for w, x in zip(weights, feature_list)]
+        total_e0 = -sum(en_contributions)
+
+        # Build HEnergyNode which matches the AtomizationEnergy module.
+        feature_sizes = self.torch_module.feature_sizes
+        feature_sizes = (total_e0.shape[1], *feature_sizes)
+        henergy_mod = target_modules.HEnergy(feature_sizes=feature_sizes, first_is_interacting=False, n_target=1)
+
+        en_0_layer = henergy_mod.layers[0]
+        en_0_layer.weight = torch.nn.Parameter(total_e0)
+        en_0_layer.bias = None
+
+        for lay1, lay2 in zip(henergy_mod.layers[1:], self.torch_module.layers):
+            lay1.weight = lay2.weight
+            # lay1.bias.set_(torch.zeros_like(lay1.bias))
+            lay1.bias = lay2.bias
+
+        henergy_node = HEnergyNode(f"{self.name}[HEnergy]", new_parents, module=henergy_mod)
+
+        return henergy_node

--- a/hippynn/interfaces/lammps_interface/mliap_interface.py
+++ b/hippynn/interfaces/lammps_interface/mliap_interface.py
@@ -1,7 +1,6 @@
 """
 Interface for creating LAMMPS MLIAP Unified models.
 """
-import pickle
 import warnings
 
 import numpy as np
@@ -20,7 +19,7 @@ from hippynn.graphs.nodes.indexers import PaddingIndexer
 from hippynn.graphs.nodes.physics import GradientNode, VecMag
 from hippynn.graphs.nodes.inputs import SpeciesNode
 from hippynn.graphs.nodes.pairs import PairFilter
-
+from hippynn.graphs.nodes.targets import AtomizationEnergyNode
 
 class MLIAPInterface(MLIAPUnified):
     """
@@ -175,6 +174,9 @@ def setup_LAMMPS_graph(energy):
     :param energy: energy node for lammps interface
     :return: graph for computing from lammps MLIAP unified inputs.
     """
+    if isinstance(energy, AtomizationEnergyNode):
+        energy = energy.create_henergy_equivalent()
+
     required_nodes = [energy]
 
     why = "Generating LAMMPS Calculator interface"

--- a/hippynn/layers/algebra.py
+++ b/hippynn/layers/algebra.py
@@ -47,15 +47,18 @@ class AtLeast2D(torch.nn.Module):
 
 
 class ValueMod(torch.nn.Module):
-    def __init__(self, value):
+    def __init__(self, value, convert=True):
         super().__init__()
-        if not isinstance(value, torch.Tensor):
+        if not isinstance(value, torch.Tensor) and convert:
             value = torch.tensor(value, dtype=torch.get_default_dtype())
 
-        self.register_buffer("value", value)
+        if isinstance(value, torch.Tensor):
+            self.register_buffer("value", value)
+        else:
+            self.value = value
 
     def extra_repr(self):
-        return str(self.value.data)
+        return str(self.value)
 
     def forward(self):
         return self.value

--- a/hippynn/networks/hipnn.py
+++ b/hippynn/networks/hipnn.py
@@ -124,7 +124,7 @@ class Hipnn(torch.nn.Module):
 
         if isinstance(self.nf, int):
             if n_interaction_layers is None:
-                raise ValueError("Must provide n_interaction layers if n_features is a single integer.")
+                raise ValueError("Must provide 'n_interaction_layers' if n_features is a single integer.")
             self.feature_sizes = (self.nf_in, *(self.nf for _ in range(n_interaction_layers)))
         else:
             if n_interaction_layers is not None:

--- a/hippynn/pretraining.py
+++ b/hippynn/pretraining.py
@@ -78,7 +78,8 @@ def hierarchical_energy_initialization(
     # Decay layers E1, E2, etc... according to decay_factor
     for layer in energy_module.layers[1:]:
         layer.weight.data *= decay_factor
-        layer.bias.data *= decay_factor
+        if layer.bias is not None:
+            layer.bias.data *= decay_factor
         decay_factor *= decay_factor
 
 def set_e0_values(*args, **kwargs):

--- a/tests/atomization_conversion.py
+++ b/tests/atomization_conversion.py
@@ -1,0 +1,60 @@
+'''
+To obtain the data files needed for this example, use the script process_QM7_data.py,
+also located in this folder. The script contains further instructions for use.
+'''
+
+import torch
+
+# Setup pytorch things
+torch.set_default_dtype(torch.float64)
+
+import hippynn
+
+netname = "TEST_BAREBONES_SCRIPT"
+
+# Hyperparameters for the network
+# These are set deliberately small so that you can easily run the example on a laptop or similar.
+network_params = {
+    "possible_species": [0, 1, 6, 7, 8, 16],  # Z values of the elements in QM7
+    "n_features": 20,  # Number of neurons at each layer
+    "n_sensitivities": 20,  # Number of sensitivity functions in an interaction layer
+    "dist_soft_min": 1.6,  # qm7 is in Bohr!
+    "dist_soft_max": 10.0,
+    "dist_hard_max": 12.5,
+    "n_interaction_layers": 2,  # Number of interaction blocks
+    "n_atom_layers": 3,  # Number of atom layers in an interaction block
+}
+
+# Define a model
+from hippynn.graphs import inputs, networks, targets, physics
+
+species = inputs.SpeciesNode(db_name="Z")
+positions = inputs.PositionsNode(db_name="R")
+
+network = networks.Hipnn("hipnn_model", (species, positions), module_kwargs=network_params)
+# henergy = targets.HEnergyNode("HEnergy", network, db_name="T")
+henergy = targets.AtomizationEnergyNode("HEnergy", network, db_name="T")
+
+model = hippynn.GraphModule([species,positions], [henergy.mol_energy])
+
+from hippynn import ase_interface as hai
+import ase.units, ase.build
+
+atoms = ase.build.molecule("H2O")
+
+pos = torch.as_tensor(atoms.positions / ase.units.Bohr).unsqueeze(0).to(torch.get_default_dtype())
+sp = torch.as_tensor(atoms.get_atomic_numbers()).unsqueeze(0)
+pred = hippynn.Predictor.from_graph(model)
+original_en = pred(Z=sp, R=pos)[henergy.mol_energy]
+pred.graph.print_structure()
+print("predictor output:", original_en)
+calc = hai.calculator_from_model(model, dist_unit=ase.units.Bohr)
+
+calc.module.print_structure()
+atoms.calc = calc
+ase_en = atoms.get_potential_energy() / (ase.units.kcal / ase.units.mol)
+print("ASE Energy is:", ase_en)
+print("Ratio:", ase_en/original_en)
+
+if not torch.allclose(torch.as_tensor(ase_en), original_en):
+    raise ValueError(f"Values do not match!: {ase_en},{original_en}")


### PR DESCRIPTION
This PR adds a new feature to hippynn which trains an energy predictor which is self-consistent under an atomization process; the training must be done to an appropriately normalized dataset, that is one of calculated atomization energies.

The feature should be functional with all other hippynn facilities including the ase interface and lammps interface. If it is not working, and you are somehow at this PR because it is broken, please leave a message.

Changes for this feature include:
- addition of atomization consistent node/torch module as well as vacuum feature transformation on the graph level.
- added atomization consistent option to the ani1x_training example
- tests which verify that the atomization energy module can be converted to a normal HEnergy module and used with ASE to produce the same answers.
- changes to the baseline subtraction in ani1x_training example to produce a correct atomization energy using the appropriate vacuum spin states for carbon, nitrogen, and oxygen.

Other related changes introduced here:
- better automatic determination of relative nodes using an ancestor fallback scheme
- allow valuenodes to take on pure python values (e.g. Int) instead of only torch tensors, using a keyword.
- slightly improved imports to base package
- bugfixes to hierarchical initialization and database features.
- improved error message for hip-nn creation when hyperparameters are not fully specified.