### PR TITLE
Add batched prediction to molecular dynamics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,7 +35,7 @@ New Features:
 - Added node to split by species. Can be used to calculate or plot loss by species.
 - New ASELangevinDynamics updater for MD module. Implements the algorithm used by ASE. Different from 
   older LangevinDynamics updater. Expected to be more numerically stable. 
-
+- Added batch size to MolecularDynamics class. This is passed to the model during each step.
 
 Improvements:
 -------------

--- a/hippynn/molecular_dynamics/md.py
+++ b/hippynn/molecular_dynamics/md.py
@@ -425,18 +425,21 @@ class MolecularDynamics:
         model: Predictor,
         device: Optional[torch.device] = None,
         dtype: Optional[torch.dtype] = None,
+        batch_size: Optional[int] = None
     ):
         """
         :param variables: list of Variable objects which will be tracked during simulation
         :param model: HIPNN Predictor
         :param device: device to move variables and model to, defaults to None
         :param dtype: dtype to convert all float type variable data and model parameters to, defaults to None
+        :param batch_size: batch size passed to model.__call__
         """
 
         self.variables = variables
         self.model = model
         self.device = device
         self.dtype = dtype
+        self.batch_size = batch_size
 
         self._data = dict()
 
@@ -535,6 +538,7 @@ class MolecularDynamics:
             for variable in self.variables
             for hipnn_db_name, variable_key in variable.model_input_map.items()
         }
+        model_inputs['batch_size'] = self.batch_size
 
         model_outputs = self.model(**model_inputs)
 


### PR DESCRIPTION
* add a `batch_size` parameter to the `MolecularDynamics` class
* pass it to the `Predictor.__call__` method during each `_step` of molecular dynamics

The motivation for this is to prevent OOM errors encountered when doing large ensemble sampling runs.