### PR TITLE
Fix torch.load weights_only argument compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,6 +68,12 @@ Bug Fixes:
 - KDTreeNeighbors finds at most one pair for each set of points. If pair cutoff is more than half
   the length of one of the cell sides, it will fail to identify all of the pairs. Added error if
   this occurs.
+- Starting in PyTorch 2.6, the default value of ``weights_only`` has been changed to ``True``. To maintain compatibility
+  with this release, the ``hippynn`` object ``MetricTracker`` is added the list of objects which PyTorch can load with 
+  ``weights_only=True``. Functions which are intended to load structure files have been updated to explicitly use 
+  ``weights_only=False`` by default. In such cases, the argument ``weights_only`` has been exposed to the user and a 
+  warning message has been added to the function documentation. 
+  
 
 0.0.3
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,6 +68,8 @@ Bug Fixes:
 - KDTreeNeighbors finds at most one pair for each set of points. If pair cutoff is more than half
   the length of one of the cell sides, it will fail to identify all of the pairs. Added error if
   this occurs.
+- In order to remain compatible with the latest PyTorch releases, explicitly set `weights_only=False` 
+  in calls of `torch.load`.
 
 0.0.3
 =======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -68,8 +68,6 @@ Bug Fixes:
 - KDTreeNeighbors finds at most one pair for each set of points. If pair cutoff is more than half
   the length of one of the cell sides, it will fail to identify all of the pairs. Added error if
   this occurs.
-- In order to remain compatible with the latest PyTorch releases, explicitly set `weights_only=False` 
-  in calls of `torch.load`.
 
 0.0.3
 =======

--- a/docs/source/examples/restarting.rst
+++ b/docs/source/examples/restarting.rst
@@ -28,10 +28,23 @@ the metrics of the experiment so far. This can be seen by breaking down
     )
 
 
-Simple restart
---------------
+Loading models and simple restart
+---------------------------------
 
-To restart training later, you can use the following::
+To reload a saved model, you can use::
+
+    from hippynn.experiment.serialization import load_model_from_cwd
+    model = load_model_from_cwd()
+
+The returned ``model`` object will have the original model with the best
+parameters loaded. This can then be used with, for example, the :doc:`/examples/predictor`.
+
+.. warning::
+   Loading a saved model uses ``torch.load`` with ``weights_only=False``, which employs the ``pickle`` 
+   module. It is possible to construct malicious pickle data which will execute arbitrary code during 
+   unpickling. Only load data you trust.
+
+To restart training, you can use the following::
 
     from hippynn.experiment.serialization import load_checkpoint
     check = load_checkpoint("./experiment_structure.pt", "./best_checkpoint.pt")
@@ -51,13 +64,6 @@ or to use the default filenames and load from the current directory::
    ``restore_checkpoint``. If `hippynn <= 0.0.3` is used, please keep the
    original ``restore_db`` keyword.
 
-If all you want to do is use a previously trained model, here is how to load the model only::
-
-    from hippynn.experiment.serialization import load_model_from_cwd
-    model = load_model_from_cwd()
-
-The returned ``model`` object will have the original model with the best
-parameters loaded. This can then be used with, for example, the :doc:`/examples/predictor`.
 
 Cross-device restart
 --------------------

--- a/docs/source/examples/restarting.rst
+++ b/docs/source/examples/restarting.rst
@@ -28,10 +28,10 @@ the metrics of the experiment so far. This can be seen by breaking down
     )
 
 
-Loading models and simple restart
----------------------------------
+Loading models and simple training restart
+------------------------------------------
 
-To reload a saved model, you can use::
+To load a saved model, you can use::
 
     from hippynn.experiment.serialization import load_model_from_cwd
     model = load_model_from_cwd()

--- a/hippynn/experiment/__init__.py
+++ b/hippynn/experiment/__init__.py
@@ -22,3 +22,6 @@ try:
     __all__ += ["HippynnLightningModule"]
 except ImportError:
     pass
+
+import torch
+torch.serialization.add_safe_globals([metric_tracker.MetricTracker])

--- a/hippynn/experiment/__init__.py
+++ b/hippynn/experiment/__init__.py
@@ -22,6 +22,3 @@ try:
     __all__ += ["HippynnLightningModule"]
 except ImportError:
     pass
-
-import torch
-torch.serialization.add_safe_globals([metric_tracker.MetricTracker])

--- a/hippynn/experiment/lightning_trainer.py
+++ b/hippynn/experiment/lightning_trainer.py
@@ -215,7 +215,7 @@ class HippynnLightningModule(pl.LightningModule):
             structure_file = structure_file.parent.parent
             structure_file = structure_file.joinpath(serialization.DEFAULT_STRUCTURE_FNAME)
 
-        structure_args = torch.load(structure_file, weights_only=False)
+        structure_args = torch.load(structure_file)
 
         return super().load_from_checkpoint(
             checkpoint_path, map_location=map_location, hparams_file=hparams_file, strict=strict, **structure_args, **kwargs

--- a/hippynn/experiment/lightning_trainer.py
+++ b/hippynn/experiment/lightning_trainer.py
@@ -198,7 +198,6 @@ class HippynnLightningModule(pl.LightningModule):
     @classmethod
     def load_from_checkpoint(cls, checkpoint_path, map_location=None, structure_file=None, hparams_file=None, strict=True, weights_only=False, **kwargs):
         """
-
         :param checkpoint_path:
         :param map_location:
         :param structure_file:
@@ -206,7 +205,15 @@ class HippynnLightningModule(pl.LightningModule):
         :param strict:
         :param weights_only:
         :param kwargs:
+
+        .. Warning::
+        This function uses ``torch.load`` with ``weights_only=False`` by default,
+        which can run arbitrary code from the loaded file. Only use it with files
+        you trust. You can set ``weights_only=True`` for better security, but
+        it may cause loading of the structure file to fail. 
+
         :return:
+
         """
 
         if structure_file is None:

--- a/hippynn/experiment/lightning_trainer.py
+++ b/hippynn/experiment/lightning_trainer.py
@@ -196,7 +196,7 @@ class HippynnLightningModule(pl.LightningModule):
         return
 
     @classmethod
-    def load_from_checkpoint(cls, checkpoint_path, map_location=None, structure_file=None, hparams_file=None, strict=True, **kwargs):
+    def load_from_checkpoint(cls, checkpoint_path, map_location=None, structure_file=None, hparams_file=None, strict=True, weights_only=False, **kwargs):
         """
 
         :param checkpoint_path:
@@ -204,6 +204,7 @@ class HippynnLightningModule(pl.LightningModule):
         :param structure_file:
         :param hparams_file:
         :param strict:
+        :param weights_only:
         :param kwargs:
         :return:
         """
@@ -215,7 +216,7 @@ class HippynnLightningModule(pl.LightningModule):
             structure_file = structure_file.parent.parent
             structure_file = structure_file.joinpath(serialization.DEFAULT_STRUCTURE_FNAME)
 
-        structure_args = torch.load(structure_file)
+        structure_args = torch.load(structure_file, weights_only=weights_only)
 
         return super().load_from_checkpoint(
             checkpoint_path, map_location=map_location, hparams_file=hparams_file, strict=strict, **structure_args, **kwargs

--- a/hippynn/experiment/lightning_trainer.py
+++ b/hippynn/experiment/lightning_trainer.py
@@ -215,7 +215,7 @@ class HippynnLightningModule(pl.LightningModule):
             structure_file = structure_file.parent.parent
             structure_file = structure_file.joinpath(serialization.DEFAULT_STRUCTURE_FNAME)
 
-        structure_args = torch.load(structure_file)
+        structure_args = torch.load(structure_file, weights_only=False)
 
         return super().load_from_checkpoint(
             checkpoint_path, map_location=map_location, hparams_file=hparams_file, strict=strict, **structure_args, **kwargs

--- a/hippynn/experiment/metric_tracker.py
+++ b/hippynn/experiment/metric_tracker.py
@@ -3,6 +3,7 @@ Keep track of training metrics over the experiment
 """
 import copy
 import warnings
+import torch
 
 try:
     from hippynn.plotting import plot_all_over_time
@@ -129,6 +130,8 @@ class MetricTracker:
 
     def plot_over_time(self):
         plot_all_over_time(self.epoch_metric_values, self.epoch_best_metric_values)
+
+torch.serialization.add_safe_globals([MetricTracker])
 
 
 # Driver for printing evaluation table results, with * for better entries.

--- a/hippynn/experiment/serialization.py
+++ b/hippynn/experiment/serialization.py
@@ -123,10 +123,10 @@ def load_saved_tensors(structure_fname: str, state_fname: str, **kwargs) -> Tupl
     """
 
     with open(structure_fname, "rb") as pfile:
-        structure = torch.load(pfile, **kwargs)
+        structure = torch.load(pfile, weights_only=False, **kwargs)
 
     with open(state_fname, "rb") as pfile:
-        state = torch.load(pfile, **kwargs)
+        state = torch.load(pfile, weights_only=False, **kwargs)
     return structure, state
 
 

--- a/hippynn/experiment/serialization.py
+++ b/hippynn/experiment/serialization.py
@@ -123,10 +123,10 @@ def load_saved_tensors(structure_fname: str, state_fname: str, **kwargs) -> Tupl
     """
 
     with open(structure_fname, "rb") as pfile:
-        structure = torch.load(pfile, weights_only=False, **kwargs)
+        structure = torch.load(pfile, **kwargs)
 
     with open(state_fname, "rb") as pfile:
-        state = torch.load(pfile, weights_only=False, **kwargs)
+        state = torch.load(pfile, **kwargs)
     return structure, state
 
 

--- a/hippynn/experiment/serialization.py
+++ b/hippynn/experiment/serialization.py
@@ -117,11 +117,11 @@ def load_saved_tensors(structure_fname: str, state_fname: str, weights_only: boo
     """
     Load torch tensors from file.
 
-    .. warning::
-       This function uses ``torch.load`` with ``weights_only=False`` by default,
-       which can run arbitrary code from the loaded file. Only use it with files
-       you trust. You can set ``weights_only=True`` for better security, but
-       it may cause loading of the structure file to fail. 
+    .. Warning::
+        This function uses ``torch.load`` with ``weights_only=False`` by default,
+        which can run arbitrary code from the loaded file. Only use it with files
+        you trust. You can set ``weights_only=True`` for better security, but
+        it may cause loading of the structure file to fail. 
 
     :param structure_fname: name of the structure file
     :param state_fname: name of the state file
@@ -144,6 +144,12 @@ def load_checkpoint(
     Load checkpoint file from given filename.
 
     For details more information on to use this function, see :doc:`/examples/restarting`.
+
+    .. Warning::
+        This function uses ``torch.load`` with ``weights_only=False`` by default,
+        which can run arbitrary code from the loaded file. Only use it with files
+        you trust. You can set ``weights_only=True`` for better security, but
+        it may cause loading of the structure file to fail. 
 
     :param structure_fname: name of the structure file
     :param state_fname: name of the state file
@@ -180,6 +186,12 @@ def load_checkpoint_from_cwd(map_location=None, model_device=None, weights_only=
     """
     Same as ``load_checkpoint``, but using default filenames.
 
+    .. Warning::
+        This function uses ``torch.load`` with ``weights_only=False`` by default,
+        which can run arbitrary code from the loaded file. Only use it with files
+        you trust. You can set ``weights_only=True`` for better security, but
+        it may cause loading of the structure file to fail. 
+
     :param map_location: device mapping argument for ``torch.load``, defaults to None
     :type map_location: Union[str, dict, torch.device, Callable], optional
     :param model_device: automatically handle device mapping, defaults to None
@@ -197,6 +209,12 @@ def load_checkpoint_from_cwd(map_location=None, model_device=None, weights_only=
 def load_model_from_cwd(map_location=None, model_device=None, weights_only=False, **kwargs) -> GraphModule:
     """
     Only load model from current working directory.
+
+    .. Warning::
+        This function uses ``torch.load`` with ``weights_only=False`` by default,
+        which can run arbitrary code from the loaded file. Only use it with files
+        you trust. You can set ``weights_only=True`` for better security, but
+        it may cause loading of the structure file to fail. 
 
     :param map_location: device mapping argument for ``torch.load``, defaults to None
     :type map_location: Union[str, dict, torch.device, Callable], optional

--- a/hippynn/experiment/serialization.py
+++ b/hippynn/experiment/serialization.py
@@ -117,6 +117,12 @@ def load_saved_tensors(structure_fname: str, state_fname: str, weights_only: boo
     """
     Load torch tensors from file.
 
+    .. warning::
+       This function uses ``torch.load`` with ``weights_only=False`` by default,
+       which can run arbitrary code from the loaded file. Only use it with files
+       you trust. You can set ``weights_only=True`` for better security, but
+       it may cause loading of the structure file to fail. 
+
     :param structure_fname: name of the structure file
     :param state_fname: name of the state file
     :param weights_only: passed to ``torch.load``

--- a/hippynn/experiment/serialization.py
+++ b/hippynn/experiment/serialization.py
@@ -113,7 +113,7 @@ def check_mapping_devices(map_location, model_device):
     return map_location, model_device
 
 
-def load_saved_tensors(structure_fname: str, state_fname: str, weights_only=False, **kwargs) -> Tuple[dict, dict]:
+def load_saved_tensors(structure_fname: str, state_fname: str, weights_only: bool = False, **kwargs) -> Tuple[dict, dict]:
     """
     Load torch tensors from file.
 

--- a/hippynn/experiment/serialization.py
+++ b/hippynn/experiment/serialization.py
@@ -113,17 +113,18 @@ def check_mapping_devices(map_location, model_device):
     return map_location, model_device
 
 
-def load_saved_tensors(structure_fname: str, state_fname: str, **kwargs) -> Tuple[dict, dict]:
+def load_saved_tensors(structure_fname: str, state_fname: str, weights_only=False, **kwargs) -> Tuple[dict, dict]:
     """
     Load torch tensors from file.
 
     :param structure_fname: name of the structure file
     :param state_fname: name of the state file
+    :param weights_only: passed to ``torch.load``
     :return: loaded dictionaries of checkpoint and model parameters
     """
 
     with open(structure_fname, "rb") as pfile:
-        structure = torch.load(pfile, **kwargs)
+        structure = torch.load(pfile, weights_only=weights_only, **kwargs)
 
     with open(state_fname, "rb") as pfile:
         state = torch.load(pfile, **kwargs)
@@ -131,7 +132,7 @@ def load_saved_tensors(structure_fname: str, state_fname: str, **kwargs) -> Tupl
 
 
 def load_checkpoint(
-    structure_fname: str, state_fname: str, restart_db=False, map_location=None, model_device=None, **kwargs
+    structure_fname: str, state_fname: str, restart_db=False, map_location=None, model_device=None, weights_only=False, **kwargs
 ) -> dict:
     """
     Load checkpoint file from given filename.
@@ -143,13 +144,14 @@ def load_checkpoint(
     :param restart_db: restore database or not, defaults to False
     :param map_location: device mapping argument for ``torch.load``, defaults to None
     :param model_device: automatically handle device mapping. Defaults to None, defaults to None
+    :param weights_only: passed to ``torch.load``, defaults to False
     :return: experiment structure
     """
 
     # we need keep the original map_location value for the if
     mapped, model_device = check_mapping_devices(map_location, model_device)
     kwargs["map_location"] = mapped
-    structure, state = load_saved_tensors(structure_fname, state_fname, **kwargs)
+    structure, state = load_saved_tensors(structure_fname, state_fname, weights_only=weights_only, **kwargs)
 
     # transfer stuff back to model_device
     structure = restore_checkpoint(structure, state, restart_db=restart_db)
@@ -168,35 +170,39 @@ def load_checkpoint(
     return structure
 
 
-def load_checkpoint_from_cwd(map_location=None, model_device=None, **kwargs) -> dict:
+def load_checkpoint_from_cwd(map_location=None, model_device=None, weights_only=False, **kwargs) -> dict:
     """
     Same as ``load_checkpoint``, but using default filenames.
 
     :param map_location: device mapping argument for ``torch.load``, defaults to None
     :type map_location: Union[str, dict, torch.device, Callable], optional
-    :param model_device: automatically handle device mapping. Defaults to None, defaults to None
+    :param model_device: automatically handle device mapping, defaults to None
     :type model_device: Union[int, str, torch.device], optional
+    :param weights_only: passed to ``torch.load``, defaults to False
+    :type weights_only: bool, optional
     :return: experiment structure
     :rtype: dict
     """
     return load_checkpoint(
-        DEFAULT_STRUCTURE_FNAME, "best_checkpoint.pt", map_location=map_location, model_device=model_device, **kwargs
+        DEFAULT_STRUCTURE_FNAME, "best_checkpoint.pt", map_location=map_location, model_device=model_device, weights_only=weights_only, **kwargs
     )
 
 
-def load_model_from_cwd(map_location=None, model_device=None, **kwargs) -> GraphModule:
+def load_model_from_cwd(map_location=None, model_device=None, weights_only=False, **kwargs) -> GraphModule:
     """
     Only load model from current working directory.
 
     :param map_location: device mapping argument for ``torch.load``, defaults to None
     :type map_location: Union[str, dict, torch.device, Callable], optional
-    :param model_device: automatically handle device mapping. Defaults to None, defaults to None
+    :param model_device: automatically handle device mapping, defaults to None
     :type model_device: Union[int, str, torch.device], optional
+    :param weights_only: passed to ``torch.load``, defaults to False
+    :type weights_only: bool, optional
     :return: model with reloaded parameters
     """
     mapped, model_device = check_mapping_devices(map_location, model_device)
     kwargs["map_location"] = mapped
-    structure, state = load_saved_tensors("experiment_structure.pt", "best_model.pt", **kwargs)
+    structure, state = load_saved_tensors("experiment_structure.pt", "best_model.pt", weights_only=weights_only, **kwargs)
 
     model = structure["training_modules"].model
     model.load_state_dict(state)

--- a/hippynn/graphs/ensemble.py
+++ b/hippynn/graphs/ensemble.py
@@ -23,6 +23,7 @@ def make_ensemble(
     inputs: List[str] = "auto",
     prefix: str = "ensemble_",
     quiet=False,
+    weights_only=False,
 ) -> Tuple[GraphModule, Tuple[Dict[str, int], Dict[str, int]]]:
 
     """
@@ -57,11 +58,12 @@ def make_ensemble(
     :param inputs: list of db_name strings of the string 'auto', which will attempt to infer.
     :param prefix: specifies the prefix for the db_name of created ensemble nodes.
     :param quiet: whether to print information about the constructed ensemble.
+    :param weights_only: passed to ``torch.load``
     :return: ensemble GraphModule, (intput_info, output_info)
     """
 
     # Phase 0: Make sure we are dealing with GraphModules
-    graphs: List[GraphModule] = get_graphs(models)
+    graphs: List[GraphModule] = get_graphs(models, weights_only=weights_only)
 
     # Phase 1: Figure out what the ensemble will look like.
     if inputs == "auto":
@@ -96,7 +98,7 @@ def make_ensemble(
 
 # TODO: Potentially move this function, or part of it, into experiment.serialization?
 # TODO ; It seems possible that someone might want to load several models without ensembling them.
-def get_graphs(models: Union[List[Union[str, GraphModule, _BaseNode]], str]) -> List[GraphModule]:
+def get_graphs(models: Union[List[Union[str, GraphModule, _BaseNode]], str], weights_only: bool = False) -> List[GraphModule]:
     """
     Take a simple spec for modeled variables (glob for model directories, list of graphs, list of output nodes)
     and convert this into a list of graph modules.
@@ -111,6 +113,7 @@ def get_graphs(models: Union[List[Union[str, GraphModule, _BaseNode]], str]) -> 
     or a string, which is used with glob to specify the list of strings.
 
     :param models:
+    :param weights_only: passed to ``torch.load``
     :return:
     """
 
@@ -128,7 +131,7 @@ def get_graphs(models: Union[List[Union[str, GraphModule, _BaseNode]], str]) -> 
                 device = device_fallback()
             with active_directory(model, create=False):
                 try:
-                    model = load_model_from_cwd(map_location=device)
+                    model = load_model_from_cwd(map_location=device, weights_only=weights_only)
                 except FileNotFoundError:
                     import warnings
 

--- a/hippynn/graphs/ensemble.py
+++ b/hippynn/graphs/ensemble.py
@@ -53,6 +53,12 @@ def make_ensemble(
 
     For more information on the `models` parameter, see the :func:`~hippynn.graphs.ensemble.get_graphs` function.
 
+    .. Warning::
+        This function uses ``torch.load`` with ``weights_only=False`` by default,
+        which can run arbitrary code from the loaded file. Only use it with files
+        you trust. You can set ``weights_only=True`` for better security, but
+        it may cause loading of the structure file to fail. 
+
     :param models: list containing str, node, or graphmodule, or str to glob for model directories.
     :param targets: list of db_name strings or the string 'auto', which will attempt to infer.
     :param inputs: list of db_name strings of the string 'auto', which will attempt to infer.
@@ -111,6 +117,12 @@ def get_graphs(models: Union[List[Union[str, GraphModule, _BaseNode]], str], wei
     - node: an output target, which will be converted to a GraphModule with automatically defined inputs.
 
     or a string, which is used with glob to specify the list of strings.
+
+    .. Warning::
+        This function uses ``torch.load`` with ``weights_only=False`` by default,
+        which can run arbitrary code from the loaded file. Only use it with files
+        you trust. You can set ``weights_only=True`` for better security, but
+        it may cause loading of the structure file to fail. 
 
     :param models:
     :param weights_only: passed to ``torch.load``

--- a/hippynn/interfaces/pyseqm_interface/gen_par.py
+++ b/hippynn/interfaces/pyseqm_interface/gen_par.py
@@ -27,8 +27,8 @@ class gen_par(torch.nn.Module):
         self.state_file = state_file
         self.par_atom_node_name = par_atom_node_name
         self.seqm_node_name = seqm_node_name
-        structure = torch.load(model_file, map_location=device)
-        state = torch.load(state_file, map_location=device)
+        structure = torch.load(model_file, map_location=device, weights_only=False)
+        state = torch.load(state_file, map_location=device, weights_only=False)
         structure["training_modules"][0].load_state_dict(state["model"])
         structure["controller"].load_state_dict(state["controller"])
         self.model = structure["training_modules"][0]

--- a/hippynn/interfaces/pyseqm_interface/gen_par.py
+++ b/hippynn/interfaces/pyseqm_interface/gen_par.py
@@ -27,8 +27,8 @@ class gen_par(torch.nn.Module):
         self.state_file = state_file
         self.par_atom_node_name = par_atom_node_name
         self.seqm_node_name = seqm_node_name
-        structure = torch.load(model_file, map_location=device, weights_only=False)
-        state = torch.load(state_file, map_location=device, weights_only=False)
+        structure = torch.load(model_file, map_location=device)
+        state = torch.load(state_file, map_location=device)
         structure["training_modules"][0].load_state_dict(state["model"])
         structure["controller"].load_state_dict(state["controller"])
         self.model = structure["training_modules"][0]

--- a/hippynn/interfaces/pyseqm_interface/gen_par.py
+++ b/hippynn/interfaces/pyseqm_interface/gen_par.py
@@ -23,6 +23,13 @@ class gen_par(torch.nn.Module):
         device=device,
         weights_only=False,
     ):
+        """ 
+        .. Warning::
+            This function uses ``torch.load`` with ``weights_only=False`` by default,
+            which can run arbitrary code from the loaded file. Only use it with files
+            you trust. You can set ``weights_only=True`` for better security, but
+            it may cause loading of the structure file to fail. 
+        """
         super().__init__()
         self.model_file = model_file
         self.state_file = state_file

--- a/hippynn/interfaces/pyseqm_interface/gen_par.py
+++ b/hippynn/interfaces/pyseqm_interface/gen_par.py
@@ -21,13 +21,14 @@ class gen_par(torch.nn.Module):
         par_atom_node_name="SEQM_Atom_Params",
         seqm_node_name="SEQM_Energy",
         device=device,
+        weights_only=False,
     ):
         super().__init__()
         self.model_file = model_file
         self.state_file = state_file
         self.par_atom_node_name = par_atom_node_name
         self.seqm_node_name = seqm_node_name
-        structure = torch.load(model_file, map_location=device)
+        structure = torch.load(model_file, map_location=device, weights_only=weights_only)
         state = torch.load(state_file, map_location=device)
         structure["training_modules"][0].load_state_dict(state["model"])
         structure["controller"].load_state_dict(state["controller"])


### PR DESCRIPTION
Add explicit argument `weights_only=False` to calls of `torch.load` to remain compatible with latest version of PyTorch, where the default for this argument is switched.