### PR TITLE
fixed random_state in Database when caching

### DIFF
--- a/hippynn/databases/database.py
+++ b/hippynn/databases/database.py
@@ -112,9 +112,15 @@ class Database:
 
         if isinstance(seed, torch.Generator):
             self.random_state = seed
+        elif isinstance(seed, torch.Tensor):
+            self.random_state = torch.Generator()
+            self.random_state.set_state(seed)
         else:
             self.random_state = torch.Generator()
-            self.random_state.manual_seed(seed)
+            try:
+                self.random_state.manual_seed(seed)
+            except Exception as eee:
+                raise ValueError(f"Invalid seed value {seed} caused error {eee}")
 
         if self.auto_split:
             if test_size is not None or valid_size is not None:


### PR DESCRIPTION
Fixed the initialization of the random state in random_state when running make_database_cache. Now seed properly handles torch.Generator.get_state vectors, integer seeds, and torch.Generator classes.