### PR TITLE
Remove overwriting nice labels

### DIFF
--- a/hippynn/graphs/graph.py
+++ b/hippynn/graphs/graph.py
@@ -106,9 +106,8 @@ class GraphModule(torch.nn.Module):
             mid = "{:3} : {}".format(node_map[computed], computed.name)
             print("{:-<20}-> {}".format(pre, mid))
 
-        node_map.update()
-        node_map.update()
-        node_map.update({n: "Out{}:".format(i) for i, n in enumerate(self.forward_output_list)})
+        
+        
 
     def node_from_name(self, name):
         for match in list(self.input_nodes) + list(self.forward_output_list):


### PR DESCRIPTION
Hey guys,

I've been playing around with this package for about a month or so, great package y'all have. 

I was looking through the `print_structure()` method in `graph.py` and I'm a bit confused about these lines:

```python
node_map.update()
node_map.update()
node_map.update({n: "Out{}:".format(i) for i, n in enumerate(self.forward_output_list)})
```

I'm not sure I understand what's happening here. The first two `update()` calls don't seem to have any arguments - are these supposed to do something? And the third one is overwriting the nice labels we created earlier (I0, O0, H0) with generic "Out0:", "Out1:" labels.

Am I missing something? Is there a reason we're overwriting the meaningful labels? The method seems to work fine without these lines, and the I0/O0/H0 labels are much more informative about what each node actually is.

I'm definitely not an expert in this stuff so I may be overlooking something. 

Thanks!