### PR TITLE
Remove unnecessary del x statement

### DIFF
--- a/hippynn/graphs/graph.py
+++ b/hippynn/graphs/graph.py
@@ -58,8 +58,6 @@ class GraphModule(torch.nn.Module):
                 else:
                     warnings.warn("Warning: object not base node:", x)
 
-        del x
-
         self.forward_output_list, self.forward_inputs_list = compute_evaluation_order(all_node_list)
 
         # Here we have to do a small dance to allow us to create a dictionary of nodes to modules.

--- a/hippynn/graphs/graph.py
+++ b/hippynn/graphs/graph.py
@@ -106,9 +106,8 @@ class GraphModule(torch.nn.Module):
             mid = "{:3} : {}".format(node_map[computed], computed.name)
             print("{:-<20}-> {}".format(pre, mid))
 
-        node_map.update()
-        node_map.update()
-        node_map.update({n: "Out{}:".format(i) for i, n in enumerate(self.forward_output_list)})
+        
+        
 
     def node_from_name(self, name):
         for match in list(self.input_nodes) + list(self.forward_output_list):


### PR DESCRIPTION
Python is already removing the name x when the loop ends so this doesn't impact the memory at all, especially since del just clears the name, not the object.