### PR TITLE
Hessian and HVP training capability for HIPPYNN

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -21,6 +21,7 @@ Jan Janssen (LANL)
 Cagri Kaymak (LANL)
 Shuhao Zhang (CMU, LANL) - Batched Optimization routines
 Michael Chigaev (LANL, UC Berkeley)
+Austin Rodriguez (Michigan State)
 
 
 Also thanks to testing and feedback from:

--- a/examples/hessian_training.py
+++ b/examples/hessian_training.py
@@ -1,0 +1,175 @@
+"""
+Example script for training HIP-NN to energies, forces, and/or Hessian data from the RTP dataset h5 file.
+Hessian-vector products (HVPs) can be used instead of full Hessians for faster training.
+
+This script was designed for an external dataset available at
+https://doi.org/10.6084/m9.figshare.29189858
+
+For info on the dataset, see the following publication:
+Rodriguez, A., Smith, J. S. & Mendoza‑Cortes, J. L.
+Does Hessian Data Improve the Performance of Machine Learning Potentials? 
+J. Chem. Theory Comput. (2025), pp. 6698–6710.
+https://doi.org/10.1021/acs.jctc.5c00402
+
+"""
+
+import torch
+import hippynn
+import ase.units
+from hippynn.graphs import inputs, networks, targets, physics
+from hippynn.graphs.nodes.base import InputNode
+from hippynn.graphs.nodes.loss import MSELoss, WeightedMSELoss
+from hippynn.graphs import GraphModule
+
+# Active directory
+active_directory = "hvp_training_run"
+
+# hippynn.custom_kernels.set_custom_kernels("triton")
+hippynn.settings.WARN_LOW_DISTANCES=False
+torch.set_default_dtype(torch.float32)
+torch.cuda.set_device("cuda:0")
+
+# === Input Nodes ===
+species = inputs.SpeciesNode(db_name="species")
+positions = inputs.PositionsNode(db_name="coordinates")
+
+# === HIPNN Model Parameters ===
+network_params = {
+    "possible_species": [0, 1, 6, 7, 8],  # Z values of the elements in RTP dataset
+    "n_features": 16,
+    "n_sensitivities": 16,
+    "dist_soft_min": 0.8,
+    "dist_soft_max": 4.5,
+    "dist_hard_max": 6.0,
+    "n_interaction_layers": 2,
+    "n_atom_layers": 2,
+}
+
+# === Build the HIPNN Model ===
+hipnn_model = networks.Hipnn("hipnn_model", (species, positions), module_kwargs=network_params)
+
+# === Energy Node ===
+energy = targets.HEnergyNode("energy", hipnn_model, db_name="energies")
+
+## === Force Node ===
+# gradients = physics.GradientNode("gradients", (energy, positions), sign=1, db_name="forces")
+force = physics.GradientNode("forces", (energy, positions), sign=-1, db_name="forces")
+
+# === Hessian Node ===
+hessian = physics.HessianNode("hessian", (energy,))
+
+# === True Hessian Node ===
+true_hessian = InputNode("hessian", db_name="hessian", index_state=physics.IdxType.Molecules)
+
+# === HVP Vector Node ===
+HVPVector = physics.HVPVectorNode("hvp_vector", (positions,), vector_type="random")
+
+# === HVP Node ===
+HVP = physics.HVPNode("hvp", (force, positions, HVPVector))
+
+# === True HVP Node ===
+TrueHVP = physics.TrueHVPNode("true_hvp", (true_hessian, HVPVector))
+
+# === Losses ===
+force_coefficient = 0.30
+hessian_coefficient = 0.09
+losses = {
+    "E-RMSE": MSELoss.of_node(energy) ** (1 / 2),
+    "F-RMSE": MSELoss.of_node(force) ** (1 / 2),
+    # "H-RMSE": WeightedMSELoss(hessian.hessian.pred, true_hessian.true, hessian.mask.pred) ** (1 / 2),
+    "HVP-RMSE": WeightedMSELoss(HVP.hvp.pred, TrueHVP.pred, HVP.mask.pred) ** (1 / 2)
+}
+
+losses["LossTotal"] = losses["E-RMSE"] + force_coefficient * losses["F-RMSE"] + hessian_coefficient * losses["HVP-RMSE"]
+
+validation_losses = {
+    "E-RMSE": MSELoss.of_node(energy) ** (1 / 2),
+    "F-RMSE": MSELoss.of_node(force) ** (1 / 2),
+    # "H-RMSE": WeightedMSELoss(hessian.hessian.pred, true_hessian.true, hessian.mask.pred) ** (1 / 2),
+    "HVP-RMSE": WeightedMSELoss(HVP.hvp.pred, TrueHVP.pred, HVP.mask.pred) ** (1 / 2)
+}
+
+# === Assemble Graph ===
+graph = GraphModule((species, positions), [energy, force, HVP])
+
+# This piece of code glues the stuff together as a pytorch model,
+# dropping things that are irrelevant for the losses defined.
+training_modules, db_info = hippynn.experiment.assemble_for_training(losses['LossTotal'], validation_losses)
+
+# Ensure total energies, forces, and Hessians loaded in float32/float64.
+torch.set_default_dtype(torch.float32)
+
+from hippynn.databases.h5_pyanitools import PyAniFileDB
+database = PyAniFileDB(
+    file="../datasets/gau-files-12k.h5", # Change this to your h5 file dataset location
+    species_key="species",  # or "Z"
+    allow_unfound=True,
+    seed=2025,
+    **db_info
+)
+
+# wb97x-6-31g*, G16. Doesn't need to be exact for most models, except atomization consistent.
+# # # Old values with singlet/triplet multiplicity only
+# # SELF_ENERGY_APPROX = {'C': -37.764142, 'H': -0.4993212, 'N': -54.4628753, 'O': -74.940046}
+# Recalculated with appropriate vacuum multiplicity
+SELF_ENERGY_APPROX = {"C": -37.8338334397, "H": -0.499321232710, "N": -54.5732824628, "O": -75.0424519384}
+SELF_ENERGY_APPROX = {k: SELF_ENERGY_APPROX[v] for k, v in zip([6, 1, 7, 8], "CHNO")}
+SELF_ENERGY_APPROX[0] = 0
+
+# compute (approximate) atomization energy by subtracting self energies
+
+# Build a lookup tensor for self energies
+max_z = max(SELF_ENERGY_APPROX.keys()) + 1  # +1 in case max Z is the last index
+lookup_table = torch.zeros(max_z, dtype=torch.float32)
+for z, energy in SELF_ENERGY_APPROX.items():
+    lookup_table[z] = energy
+
+database.arr_dict["species"] = database.arr_dict["species"].long()
+
+self_energy = lookup_table[database.arr_dict["species"]]
+self_energy = self_energy.sum(dim=1)
+database.arr_dict['energies'] = database.arr_dict["energies"] - self_energy
+
+# Convert from Hartree to kcal/mol
+kcalpmol = ase.units.kcal / ase.units.mol
+conversion = ase.units.Ha / kcalpmol
+database.arr_dict["energies"] = database.arr_dict["energies"].float() * conversion
+database.arr_dict["forces"] = database.arr_dict["forces"].float() * conversion
+database.arr_dict["hessian"] = database.arr_dict["hessian"].float() * conversion
+
+# Split the data into train, validation, and test sets
+database.make_trainvalidtest_split(test_size=0.1, valid_size=0.1)
+
+# Parameters describing the training procedure.
+from hippynn.experiment.controllers import RaiseBatchSizeOnPlateau,PatienceController
+optimizer = torch.optim.Adam(training_modules.model.parameters(), lr=1e-4)
+batch_size = 300
+scheduler =  RaiseBatchSizeOnPlateau(
+    optimizer=optimizer,
+    max_batch_size=batch_size,
+    patience=8,
+    factor=0.5,
+)
+controller = PatienceController(
+    optimizer=optimizer,
+    scheduler=scheduler,
+    batch_size=batch_size,
+    eval_batch_size=batch_size,
+    max_epochs=1000,
+    stopping_key="E-RMSE",
+    termination_patience=20
+)
+experiment_params = hippynn.experiment.SetupParams(
+    controller=controller,
+    device="cuda:0"
+)
+
+with hippynn.tools.active_directory(active_directory):
+    with hippynn.tools.log_terminal("training_log.txt", 'wt'):
+        print("Data Loaded and Network set up! Just need to train... ")
+        from hippynn.experiment import setup_and_train
+        setup_and_train(
+            training_modules=training_modules,
+            database=database,
+            setup_params=experiment_params,
+        )

--- a/examples/hessian_training.py
+++ b/examples/hessian_training.py
@@ -19,157 +19,175 @@ import ase.units
 from hippynn.graphs import inputs, networks, targets, physics
 from hippynn.graphs.nodes.base import InputNode
 from hippynn.graphs.nodes.loss import MSELoss, WeightedMSELoss
-from hippynn.graphs import GraphModule
+import os
 
-# Active directory
-active_directory = "hvp_training_run"
+def load_data(file, quiet=False):
 
-# hippynn.custom_kernels.set_custom_kernels("triton")
-hippynn.settings.WARN_LOW_DISTANCES=False
-torch.set_default_dtype(torch.float32)
-torch.cuda.set_device("cuda:0")
+    # Ensure total energies, forces, and Hessians loaded in float32/float64.
+    torch.set_default_dtype(torch.float64)
 
-# === Input Nodes ===
-species = inputs.SpeciesNode(db_name="species")
-positions = inputs.PositionsNode(db_name="coordinates")
+    
+    from hippynn.databases.h5_pyanitools import PyAniFileDB
+    database = PyAniFileDB(
+        #file="../../datasets/gau-files-12k.h5", # Change this to your h5 file dataset location
+        file=file,
+        species_key="species",  # or "Z", etc
+        allow_unfound=False, # Note: file has extraneous "iform" variable which can't beloaded with hippynn; this skips that.
+        seed=2025,
+        quiet=quiet,
+        pin_memory=torch.cuda.is_available(),
+        **db_info
+    )
 
-# === HIPNN Model Parameters ===
-network_params = {
-    "possible_species": [0, 1, 6, 7, 8],  # Z values of the elements in RTP dataset
-    "n_features": 16,
-    "n_sensitivities": 16,
-    "dist_soft_min": 0.8,
-    "dist_soft_max": 4.5,
-    "dist_hard_max": 6.0,
-    "n_interaction_layers": 2,
-    "n_atom_layers": 2,
-}
+    # compute (approximate) atomization energy by subtracting self energies
 
-# === Build the HIPNN Model ===
-hipnn_model = networks.Hipnn("hipnn_model", (species, positions), module_kwargs=network_params)
+    # wb97x-6-31g*, G16. Doesn't need to be exact for most models, except atomization consistent.
+    # # # Old values with singlet/triplet multiplicity only
+    # # SELF_ENERGY_APPROX = {'C': -37.764142, 'H': -0.4993212, 'N': -54.4628753, 'O': -74.940046}
+    # Recalculated with appropriate vacuum multiplicity
+    SELF_ENERGY_APPROX = {"C": -37.8338334397, "H": -0.499321232710, "N": -54.5732824628, "O": -75.0424519384}
+    SELF_ENERGY_APPROX = {k: SELF_ENERGY_APPROX[v] for k, v in zip([6, 1, 7, 8], "CHNO")}
+    SELF_ENERGY_APPROX[0] = 0
+    # Build a lookup tensor for self energies
+    max_z = max(SELF_ENERGY_APPROX.keys()) + 1  # +1 in case max Z is the last index
+    lookup_table = torch.zeros(max_z, dtype=torch.float32)
+    for z, energy in SELF_ENERGY_APPROX.items():
+        lookup_table[z] = energy
 
-# === Energy Node ===
-energy = targets.HEnergyNode("energy", hipnn_model, db_name="energies")
+    database.arr_dict["species"] = database.arr_dict["species"].long()
 
-## === Force Node ===
-# gradients = physics.GradientNode("gradients", (energy, positions), sign=1, db_name="forces")
-force = physics.GradientNode("forces", (energy, positions), sign=-1, db_name="forces")
+    self_energy = lookup_table[database.arr_dict["species"]]
+    self_energy = self_energy.sum(dim=1)
+    database.arr_dict['energies'] = database.arr_dict["energies"] - self_energy
 
-# === Hessian Node ===
-hessian = physics.HessianNode("hessian", (energy,))
 
-# === True Hessian Node ===
-true_hessian = InputNode("hessian", db_name="hessian", index_state=physics.IdxType.Molecules)
+    # Convert from Hartree to kcal/mol
+    kcalpmol = ase.units.kcal / ase.units.mol
+    conversion = ase.units.Ha / kcalpmol
+    for k in ["energies", "forces", "hessian"]:
+        database.arr_dict[k] = database.arr_dict[k] * conversion
 
-# === HVP Vector Node ===
-HVPVector = physics.HVPVectorNode("hvp_vector", (positions,), vector_type="random")
+    for k, v in database.arr_dict.items():
+        if v.dtype == torch.float64:
+            database.arr_dict[k] = v.to(torch.float32)
 
-# === HVP Node ===
-HVP = physics.HVPNode("hvp", (force, positions, HVPVector))
+    torch.set_default_dtype(torch.float32) # until self-energy subtracted
+    return database
 
-# === True HVP Node ===
-TrueHVP = physics.TrueHVPNode("true_hvp", (true_hessian, HVPVector))
 
-# === Losses ===
-force_coefficient = 0.30
-hessian_coefficient = 0.09
-losses = {
-    "E-RMSE": MSELoss.of_node(energy) ** (1 / 2),
-    "F-RMSE": MSELoss.of_node(force) ** (1 / 2),
-    # "H-RMSE": WeightedMSELoss(hessian.hessian.pred, true_hessian.true, hessian.mask.pred) ** (1 / 2),
-    "HVP-RMSE": WeightedMSELoss(HVP.hvp.pred, TrueHVP.pred, HVP.mask.pred) ** (1 / 2)
-}
 
-losses["LossTotal"] = losses["E-RMSE"] + force_coefficient * losses["F-RMSE"] + hessian_coefficient * losses["HVP-RMSE"]
 
-validation_losses = {
-    "E-RMSE": MSELoss.of_node(energy) ** (1 / 2),
-    "F-RMSE": MSELoss.of_node(force) ** (1 / 2),
-    # "H-RMSE": WeightedMSELoss(hessian.hessian.pred, true_hessian.true, hessian.mask.pred) ** (1 / 2),
-    "HVP-RMSE": WeightedMSELoss(HVP.hvp.pred, TrueHVP.pred, HVP.mask.pred) ** (1 / 2)
-}
+if __name__ == "__main__":
+    # Active directory
+    active_directory = "TEST_hvp_training_run"
+    data_location = "../../datasets/OpenREACT-CHON-EFH/"
 
-# === Assemble Graph ===
-graph = GraphModule((species, positions), [energy, force, HVP])
+    # hippynn.custom_kernels.set_custom_kernels("triton")
+    hippynn.settings.WARN_LOW_DISTANCES=False
+    torch.set_default_dtype(torch.float32)
 
-# This piece of code glues the stuff together as a pytorch model,
-# dropping things that are irrelevant for the losses defined.
-training_modules, db_info = hippynn.experiment.assemble_for_training(losses['LossTotal'], validation_losses)
+    if torch.cuda.is_available():
+        torch.set_default_device("cuda:0")
 
-# Ensure total energies, forces, and Hessians loaded in float32/float64.
-torch.set_default_dtype(torch.float32)
 
-from hippynn.databases.h5_pyanitools import PyAniFileDB
-database = PyAniFileDB(
-    file="../datasets/gau-files-12k.h5", # Change this to your h5 file dataset location
-    species_key="species",  # or "Z"
-    allow_unfound=True,
-    seed=2025,
-    **db_info
-)
+    # === HIPNN Model Parameters ===
+    network_params = {
+        "possible_species": [0, 1, 6, 7, 8],  # Z values of the elements in RTP dataset
+        "n_features": 32,     # example value! production run might use more.
+        "n_sensitivities": 16,
+        "dist_soft_min": 0.8,
+        "dist_soft_max": 5.5,
+        "dist_hard_max": 6.0,
+        "n_interaction_layers": 1, # production might use 2 interactions
+        "n_atom_layers": 4,
+        "l_max": 2,
+        "n_max": 3,
+    }
 
-# wb97x-6-31g*, G16. Doesn't need to be exact for most models, except atomization consistent.
-# # # Old values with singlet/triplet multiplicity only
-# # SELF_ENERGY_APPROX = {'C': -37.764142, 'H': -0.4993212, 'N': -54.4628753, 'O': -74.940046}
-# Recalculated with appropriate vacuum multiplicity
-SELF_ENERGY_APPROX = {"C": -37.8338334397, "H": -0.499321232710, "N": -54.5732824628, "O": -75.0424519384}
-SELF_ENERGY_APPROX = {k: SELF_ENERGY_APPROX[v] for k, v in zip([6, 1, 7, 8], "CHNO")}
-SELF_ENERGY_APPROX[0] = 0
+    # === Build the HIPNN Model ===
+    
+    # usual setup / targets
+    species = inputs.SpeciesNode(db_name="species")
+    positions = inputs.PositionsNode(db_name="coordinates")
+    hipnn_model = networks.HipHopnn("hipnn_model", (species, positions), module_kwargs=network_params)
+    energy = targets.HEnergyNode("energy", hipnn_model, db_name="energies")
+    force = physics.GradientNode("forces", (energy, positions), sign=-1, db_name="forces")
 
-# compute (approximate) atomization energy by subtracting self energies
+    
+    hessian = physics.HessianNode("hessian", (energy,)) # hessian of model
+    true_hessian = InputNode("hessian", db_name="hessian", index_state=physics.IdxType.Molecules) # actual hessian
+    HVPVector = physics.HVPVectorNode("hvp_vector", (positions,), vector_type="random") # probing vector
+    HVP = physics.HVPNode("hvp", (force, positions, HVPVector)) # efficient HVP product
+    TrueHVP = physics.TrueHVPNode("true_hvp", (true_hessian, HVPVector)) # product with true hessian
 
-# Build a lookup tensor for self energies
-max_z = max(SELF_ENERGY_APPROX.keys()) + 1  # +1 in case max Z is the last index
-lookup_table = torch.zeros(max_z, dtype=torch.float32)
-for z, energy in SELF_ENERGY_APPROX.items():
-    lookup_table[z] = energy
+    # === Losses ===
+    # Coefficients derived from work on ANI, see manuscript.
+    force_coefficient = 0.30
+    hessian_coefficient = 0.09
+    losses = {
+        "E-RMSE": MSELoss.of_node(energy) ** (1 / 2),
+        "F-RMSE": MSELoss.of_node(force) ** (1 / 2),
+        # Uncomment (comment) the next line if you want (don't want) the network to evaluate the full hessian loss -- this is very slow.
+        # "H-RMSE": WeightedMSELoss(hessian.hessian.pred, true_hessian.true, hessian.mask.pred) ** (1 / 2),
+        "HVP-RMSE": WeightedMSELoss(HVP.hvp.pred, TrueHVP.pred, HVP.mask.pred) ** (1 / 2)
+    }
 
-database.arr_dict["species"] = database.arr_dict["species"].long()
+    losses["LossTotal"] = losses["E-RMSE"] + force_coefficient * losses["F-RMSE"] + hessian_coefficient * losses["HVP-RMSE"]
 
-self_energy = lookup_table[database.arr_dict["species"]]
-self_energy = self_energy.sum(dim=1)
-database.arr_dict['energies'] = database.arr_dict["energies"] - self_energy
+    # This piece of code glues the stuff together as a pytorch model,
+    # dropping things that are irrelevant for the losses defined.
+    training_modules, db_info = hippynn.experiment.assemble_for_training(losses['LossTotal'], validation_losses=losses)
 
-# Convert from Hartree to kcal/mol
-kcalpmol = ase.units.kcal / ase.units.mol
-conversion = ase.units.Ha / kcalpmol
-database.arr_dict["energies"] = database.arr_dict["energies"].float() * conversion
-database.arr_dict["forces"] = database.arr_dict["forces"].float() * conversion
-database.arr_dict["hessian"] = database.arr_dict["hessian"].float() * conversion
+    database = load_data(os.path.join(data_location, "molecules-RTP.h5"))
+    # Split the data into train, validation, and test sets
+    database.make_trainvalidtest_split(test_size=0.1, valid_size=0.1)
 
-# Split the data into train, validation, and test sets
-database.make_trainvalidtest_split(test_size=0.1, valid_size=0.1)
+    # Parameters describing the training procedure.
+    from hippynn.experiment.controllers import RaiseBatchSizeOnPlateau,PatienceController
+    optimizer = torch.optim.Adam(training_modules.model.parameters(), lr=1e-3)
+    batch_size = 64
+    scheduler =  RaiseBatchSizeOnPlateau(
+        optimizer=optimizer,
+        max_batch_size=batch_size,
+        patience=5, # might be longer for production run
+        factor=0.5,
+    )
+    controller = PatienceController(
+        optimizer=optimizer,
+        scheduler=scheduler,
+        batch_size=batch_size,
+        eval_batch_size=batch_size,
+        max_epochs=100, # might be longer for production run
+        stopping_key="E-RMSE",
+        termination_patience=20
+    )
+    experiment_params = hippynn.experiment.SetupParams(
+        controller=controller,
+    )
 
-# Parameters describing the training procedure.
-from hippynn.experiment.controllers import RaiseBatchSizeOnPlateau,PatienceController
-optimizer = torch.optim.Adam(training_modules.model.parameters(), lr=1e-4)
-batch_size = 300
-scheduler =  RaiseBatchSizeOnPlateau(
-    optimizer=optimizer,
-    max_batch_size=batch_size,
-    patience=8,
-    factor=0.5,
-)
-controller = PatienceController(
-    optimizer=optimizer,
-    scheduler=scheduler,
-    batch_size=batch_size,
-    eval_batch_size=batch_size,
-    max_epochs=1000,
-    stopping_key="E-RMSE",
-    termination_patience=20
-)
-experiment_params = hippynn.experiment.SetupParams(
-    controller=controller,
-    device="cuda:0"
-)
+    with hippynn.tools.active_directory(active_directory):
+        with hippynn.tools.log_terminal("training_log.txt", 'wt'):
+            print("Data Loaded and Network set up! Just need to train... ")
+            from hippynn.experiment import setup_and_train
 
-with hippynn.tools.active_directory(active_directory):
-    with hippynn.tools.log_terminal("training_log.txt", 'wt'):
-        print("Data Loaded and Network set up! Just need to train... ")
-        from hippynn.experiment import setup_and_train
-        setup_and_train(
-            training_modules=training_modules,
-            database=database,
-            setup_params=experiment_params,
-        )
+            try:
+                setup_and_train(
+                    training_modules=training_modules,
+                    database=database,
+                    setup_params=experiment_params,
+                )
+
+            except KeyboardInterrupt:
+                print("Now testing model, interrupt again if needed!")
+
+            for data_file in ["molecules-IRC.h5", "molecules-NMS.h5"]:
+                print("Testing:", data_file)
+                path = os.path.join("..",data_location, data_file) # One more parent since we are in the model's directory now.
+                database = load_data(path, quiet=True)
+                database.split_the_rest("all data")
+                metrics = hippynn.experiment.test_model(database,training_modules.evaluator,batch_size=64, when="Final Test")
+                torch.save(metrics, "finalmetrics-" + data_file + ".pt")
+
+
+
+

--- a/hippynn/databases/database.py
+++ b/hippynn/databases/database.py
@@ -27,7 +27,7 @@ class Database:
         arr_dict: dict[str, torch.Tensor],
         inputs: list[str],
         targets: list[str],
-        seed: [int, torch.Generator],
+        seed: list[int, torch.Generator],
         test_size: Union[float, int] = None,
         valid_size: Union[float, int] = None,
         num_workers: int = 0,
@@ -47,8 +47,10 @@ class Database:
         :param valid_size: fraction of data to use in train split
         :param num_workers: passed to pytorch dataloaders
         :param pin_memory: passed to pytorch dataloaders
-        :param allow_unfound: If true, skip checking if the needed inputs and targets are found.
-           This allows setting inputs=None and/or targets=None.
+        :param allow_unfound: If true, skip validating the needed inputs and targets are found.
+            This allows setting inputs=None and/or targets=None.
+            If True, the code will attempt to load all arrays.
+            If False, the code should only open the needed arrays. 
         :param auto_split: If true, look for keys like "split_*" to make initial splits from. See write_npz() method.
         :param device: if set, move the dataset to this device after splitting.
         :param dataloader_kwargs: dictionary, passed to pytorch dataloaders in addition to num_workers, pin_memory.

--- a/hippynn/databases/h5_pyanitools.py
+++ b/hippynn/databases/h5_pyanitools.py
@@ -28,7 +28,16 @@ class PyAniMethods:
     _IGNORE_KEYS = ("path", "Jnames")
 
     # Note: assumes that all data files have 'coordinates'.
-    def extract_full_file(self, file, species_key="species"):
+    def extract_full_file(self, file, species_key="species", permit_only=None):
+        """
+        
+        :param file: filename to open
+        :param species_key: name for species variable (needs special treatment)
+        :param permit_only: if truthy, give a list of valid keys; skip others.
+        :return: batches, n_atoms_max, sys_count
+        :rtype: tuple[list, int, int]
+        """
+
         n_atoms_max = 0
         batches = []
         x = AniDataLoader(file, driver=self.driver)  # Engine=core reads the entire file at once.
@@ -41,6 +50,8 @@ class PyAniMethods:
             for k, v in c.items():
                 # Filter things we don't need
                 if k in self._IGNORE_KEYS:
+                    continue
+                if permit_only and k not in permit_only:
                     continue
 
                 # Convert to numpy
@@ -140,13 +151,15 @@ class PyAniMethods:
             for k, arr in b.items():
 
                 if k == species_key:
+                    # ANI datasets come with one set of conformations per batch, each has the same elements.
+                    # here we repeat that information for each conformation.
                     arr = np.repeat(arr, n_sys, axis=0)
 
                 # set up slicing for non-batch axes
                 where = tuple(slice(0, s) for s in arr.shape[1:])
                 # add batch slicing
                 where = (slice(sys_start, sys_end), *where)
-
+                
                 # store array!
                 arr_dict[k][where] = arr
 
@@ -216,9 +229,14 @@ class PyAniFileDB(Database, PyAniMethods, Restartable):
         )
 
     def load_arrays(self, allow_unfound=False, quiet=False):
+
         if not quiet:
             print("Loading arrays from", self.file)
-        batches, n_atoms_max, sys_count = self.extract_full_file(self.file, species_key=self.species_key)
+
+        # var list if allow_founded is False
+        permit_only = (not allow_unfound) and set(self.var_list)
+
+        batches, n_atoms_max, sys_count = self.extract_full_file(self.file, species_key=self.species_key, permit_only=permit_only)
         arr_dict = self.process_batches(batches, n_atoms_max, sys_count, species_key=self.species_key)
         arr_dict = self.filter_arrays(arr_dict, quiet=quiet, allow_unfound=allow_unfound)
         return arr_dict
@@ -266,9 +284,12 @@ class PyAniDirectoryDB(Database, PyAniMethods, Restartable):
             print("Gathering data from files:\n\t", end="")
             print(*files, sep="\n\t")
 
+        # var list if allow_founded is False
+        permit_only = (not allow_unfound) and set(self.var_list)
+
         file_batches = []
         for f in progress_bar(files, desc="Data Files", unit="file"):
-            file_batches.append(self.extract_full_file(f, species_key=self.species_key))
+            file_batches.append(self.extract_full_file(f, species_key=self.species_key, permit_only=permit_only))
 
         data, max_atoms_list, sys_count = zip(*file_batches)
 

--- a/hippynn/databases/h5_pyanitools.py
+++ b/hippynn/databases/h5_pyanitools.py
@@ -90,20 +90,24 @@ class PyAniMethods:
         bsize = 0
         bkey = None
         for k, v in batch.items():
+            shape_scheme[k] = list(v.shape)
             for i, l in enumerate(v.shape):
                 if i == 0:
                     continue  # Don't pad the batch index
-                if l == n_atoms:
+                # Check if size of axis is multiple of num_atoms
+                if l % n_atoms == 0:
+                    scale = l // n_atoms
                     padding_scheme[k].append(i)
-                    # Use the largest 0th-axis shape that has an atom index
-                    # as the indicator key for the batch size
-                    this_bsize = v.shape[0]
-                    if this_bsize > bsize:
-                        bsize = this_bsize
-                        bkey = k
-            shape_scheme[k] = list(v.shape)
-            for axis in padding_scheme[k]:
-                shape_scheme[k][axis] = n_atoms_max
+                    shape_scheme[k][i] = scale * n_atoms_max
+
+            # Use the largest 0th-axis shape that has an atom index
+            # as the indicator key for the batch size
+            if len(padding_scheme[k]) > 0:
+                this_bsize = v.shape[0]
+                if this_bsize > bsize:
+                    bsize = this_bsize
+                    bkey = k
+
             shape_scheme[k][0] = sys_count
 
         padding_scheme["sys_number"] = []
@@ -111,7 +115,7 @@ class PyAniMethods:
 
     def process_batches(self, batches, n_atoms_max, sys_count, species_key="species"):
 
-        # Get padding abd shape info and batch size key
+        # Get padding and shape info and batch size key
         padding_scheme, shape_scheme, size_key = self.determine_key_structure(batches, sys_count, n_atoms_max, species_key=species_key)
 
         # add system numbers to the final arrays

--- a/hippynn/graphs/nodes/physics.py
+++ b/hippynn/graphs/nodes/physics.py
@@ -67,6 +67,178 @@ class MultiGradientNode(AutoKw, MultiNode):
         super().__init__(name, parents, signs=signs, **kwargs)
 
 
+class HessianNode(ExpandParents, AutoKw, MultiNode):
+    """
+    Node that computes the Hessian (second derivatives of energy)
+    via gradients of force w.r.t. coordinates or
+    second gradients of enery w.r.t. coordinates.
+    """
+
+    input_names = "forces", "coordinates", "nonblank"
+    output_names = "hessian", "mask"
+    output_index_states = (IdxType.Molecules, IdxType.Molecules)
+    auto_module_class = physics_layers.Hessian
+
+    @parent_expander.matchlen(1)
+    def expansion0(self, source, *, purpose, **kwargs):
+        # Infer positions from energy or force node
+        return source, find_unique_relative(source, PositionsNode, why_desc=purpose)
+
+    @parent_expander.match(Energies, PositionsNode)
+    def expansion1(self, energy, positions, *, purpose, **kwargs):
+        energy = energy.main_output
+        possible_grads = [child for child in energy.children if (isinstance(child, GradientNode) and child.coordinates == positions)]
+        
+        if len(possible_grads) == 1:
+            # if we found a unique gradient, use that
+            force = possible_grads[0]
+        elif len(possible_grads)==0:
+            # if no gradient was found, make our own
+            force = GradientNode("forces", (energy, positions), sign=-1)
+        elif len(possible_grads)>1:
+            raise NodeAmbiguityError("Unable to automatically determine gradient of energy as multiple gradient nodes are present.")
+        
+        return force, positions
+
+    @parent_expander.match(GradientNode, PositionsNode)
+    def expansion2(self, force, coordinates, *, purpose, **kwargs):
+        # always use forces, not gradients
+        if force.sign == +1:
+            force = -1 * force
+        return force, coordinates
+    
+    @parent_expander.match(Node, PositionsNode)
+    def expansion3(self, force, coordinates, *, purpose, **kwargs):
+    
+        if not isinstance(force, GradientNode) and not any(isinstance(f, GradientNode) for f in force.get_all_parents()):
+            warnings.warn(f"Input to hessian node doesn't appear to be a force or child of a force! Got node: {force}")
+
+        encoder, _ = acquire_encoding_padding((force, coordinates), species_set=None, purpose=purpose)
+        return force, coordinates, encoder
+
+    @parent_expander.match(Node, PositionsNode, Encoder)
+    def expansion4(self, force, coordinates, encoder, **kwargs):
+        coordinates.requires_grad = True
+        return force, coordinates, encoder.nonblank
+
+    parent_expander.assertlen(3)
+    parent_expander.get_main_outputs()
+    parent_expander.require_idx_states(IdxType.MolAtom, IdxType.MolAtom, None)
+
+
+    def __init__(self, name, parents, module="auto", **kwargs):
+        parents = self.expand_parents(parents)
+        self._index_state = IdxType.Molecules
+        self.module_kwargs = {}
+        super().__init__(name, parents, module=module, **kwargs)
+
+
+class HVPVectorNode(ExpandParents, AutoKw, SingleNode):
+    """
+    Outputs a tensor with a determined number of random or one-hot vectors per molecule
+    """
+    input_names = "coordinates", "nonblank"
+    index_state = IdxType.MolAtom
+    auto_module_class = physics_layers.HVPVector
+
+    @parent_expander.match(PositionsNode)
+    def expand_from_positions(self, positions, *, purpose=None, **kwargs):
+        encoder, _ = acquire_encoding_padding((positions,), species_set=None, purpose=purpose)
+        return positions, encoder.nonblank
+    
+    parent_expander.assertlen(2)
+    parent_expander.get_main_outputs()
+    parent_expander.require_idx_states(IdxType.MolAtom, IdxType.MolAtom)
+    
+    def __init__(self, name, parents,  module="auto", vector_type="random", **kwargs):
+        self.module_kwargs = {"vector_type": vector_type}
+        parents = self.expand_parents(parents)
+        super().__init__(name, parents, module=module, **kwargs)
+
+
+class HVPNode(ExpandParents, AutoKw, MultiNode):
+    input_names = "source", "coordinates", "vector", "nonblank"
+    output_names = "hvp", "mask"
+    output_index_states = (IdxType.MolAtom, IdxType.MolAtom)
+    auto_module_class = physics_layers.HVP
+
+    @parent_expander.match(Energies, Node)
+    def expansion0(self, source, vector, *, purpose, **kwargs):
+        # Infer positions from energy or force node
+        positions = find_unique_relative(source, PositionsNode, why_desc=purpose)
+        return source, positions, vector
+
+    @parent_expander.match(Energies, PositionsNode, Node)
+    def expansion1(self, energy, positions, vector, *, purpose, **kwargs):
+        energy = energy.main_output
+        possible_grads = [child for child in energy.children if (isinstance(child, GradientNode) and child.coordinates == positions)]
+        
+        if len(possible_grads) == 1:
+            # if we found a unique gradient, use that
+            force = possible_grads[0]
+        elif len(possible_grads)==0:
+            # if no gradient was found, make our own
+            force = GradientNode("forces", (energy, positions), sign=-1)
+        elif len(possible_grads)>1:
+            raise NodeAmbiguityError("Unable to automatically determine gradient of energy as multiple gradient nodes are present.")
+        
+        return force, positions, vector
+
+    @parent_expander.match(GradientNode, PositionsNode, Node)
+    def expansion2(self, force, positions, vector, *, purpose, **kwargs):
+        # always use forces, not gradients
+        if force.sign == +1:
+            force = -1 * force
+        return force, positions, vector
+    
+    @parent_expander.match(Node, PositionsNode, Node)
+    def expansion3(self, force, positions, vector, *, purpose, **kwargs):
+    
+        if not isinstance(force, GradientNode) and not any(isinstance(f, GradientNode) for f in force.get_all_parents()):
+            warnings.warn(f"Input to HVP node doesn't appear to be a force or child of a force! Got node: {force}")
+
+        encoder, _ = acquire_encoding_padding((force, positions), species_set=None, purpose=purpose)
+        return force, positions, vector, encoder
+    
+    @parent_expander.match(Node, PositionsNode, Node, Encoder)
+    def expansion4(self, force, coordinates, vector, encoder, *, purpose, **kwargs):
+        coordinates.requires_grad = True
+        return force, coordinates, vector, encoder.nonblank
+
+    parent_expander.assertlen(4)
+    parent_expander.get_main_outputs()
+    parent_expander.require_idx_states(IdxType.MolAtom, IdxType.MolAtom, IdxType.MolAtom, None)
+
+    def __init__(self, name, parents, module="auto", **kwargs):
+        parents = self.expand_parents(parents)
+        self._index_state = IdxType.Molecules
+        self.module_kwargs = {}
+        super().__init__(name, parents, module=module, **kwargs)
+
+
+class TrueHVPNode(ExpandParents, AutoNoKw, SingleNode):
+    """
+    Computes true Hessian-vector product from database-stored Hessians and input vector
+    """
+    input_names = "hessian", "vector"
+    index_state = IdxType.MolAtom
+    auto_module_class = physics_layers.TrueHVP
+
+    @parent_expander.match(Node, HVPVectorNode)
+    def expand_from_hessian_and_vector(self, hessian, vector, **kwargs):
+        if hessian._index_state != IdxType.Molecules:
+            raise TypeError(f"Expected Molecules-indexed Hessian, got {hessian._index_state}")
+        return hessian, vector
+
+    parent_expander.get_main_outputs()
+    parent_expander.require_idx_states(IdxType.Molecules, IdxType.MolAtom)
+
+    def __init__(self, name, parents=None, module="auto", **kwargs):
+        self.module_kwargs = {}
+        parents = self.expand_parents(parents, **kwargs)
+        super().__init__(name, parents, module=module, **kwargs)
+
+
 class StressForceNode(AutoNoKw, MultiNode):
     input_names = "energy", "strain", "coordinates", "cell"
     output_names = "forces", "stress"

--- a/hippynn/graphs/nodes/physics.py
+++ b/hippynn/graphs/nodes/physics.py
@@ -16,7 +16,7 @@ from .base import (
     Node,
     find_unique_relative,
 )
-from .base.node_functions import NodeNotFound
+from .base.node_functions import NodeNotFound, NodeAmbiguityError
 from .indexers import AtomIndexer, PaddingIndexer, acquire_encoding_padding
 from .inputs import PositionsNode, SpeciesNode
 from .pairs import OpenPairIndexer
@@ -96,7 +96,7 @@ class HessianNode(ExpandParents, AutoKw, MultiNode):
             # if no gradient was found, make our own
             force = GradientNode("forces", (energy, positions), sign=-1)
         elif len(possible_grads)>1:
-            raise NodeAmbiguityError("Unable to automatically determine gradient of energy as multiple gradient nodes are present.")
+            raise NodeAmbiguityError("Unable to automatically determine correct gradient of energy, as multiple gradient nodes are already present.")
         
         return force, positions
 
@@ -109,10 +109,6 @@ class HessianNode(ExpandParents, AutoKw, MultiNode):
     
     @parent_expander.match(Node, PositionsNode)
     def expansion3(self, force, coordinates, *, purpose, **kwargs):
-    
-        if not isinstance(force, GradientNode) and not any(isinstance(f, GradientNode) for f in force.get_all_parents()):
-            warnings.warn(f"Input to hessian node doesn't appear to be a force or child of a force! Got node: {force}")
-
         encoder, _ = acquire_encoding_padding((force, coordinates), species_set=None, purpose=purpose)
         return force, coordinates, encoder
 
@@ -120,6 +116,13 @@ class HessianNode(ExpandParents, AutoKw, MultiNode):
     def expansion4(self, force, coordinates, encoder, **kwargs):
         coordinates.requires_grad = True
         return force, coordinates, encoder.nonblank
+    
+    @parent_expander.match(Node, Node, Node)
+    def check_for_grad(self, force, coordinates, encoder, **kwargs):
+        self_and_parents = {force, *force.get_ancestors()}
+        if not any(isinstance(n, (GradientNode, MultiGradientNode)) for n in self_and_parents):
+            warnings.warn(f"Input to hessian node doesn't appear to be a force or child of a force! This node: {force}")
+        return force, coordinates, encoder
 
     parent_expander.assertlen(3)
     parent_expander.get_main_outputs()

--- a/hippynn/layers/algebra.py
+++ b/hippynn/layers/algebra.py
@@ -26,6 +26,14 @@ class _WeightedLoss(torch.nn.Module):
 
     def forward(self, pred, true, weights):
         unweighted_loss = self.loss_func(pred, true, reduction='none')
+        # Ensure weights broadcast correctly
+        assert weights.shape == unweighted_loss.shape, (
+            f"Shape mismatch: weights {weights.shape}, loss {unweighted_loss.shape}"
+        )
+
+        # Convert mask to float
+        weights = weights.to(dtype=unweighted_loss.dtype)
+
         normalized_weights = weights/torch.mean(weights)
         weighted_loss = (normalized_weights*unweighted_loss).mean()
         return weighted_loss

--- a/hippynn/layers/physics.py
+++ b/hippynn/layers/physics.py
@@ -34,6 +34,132 @@ class MultiGradient(torch.nn.Module):
         grads = torch.autograd.grad(molecular_energies.sum(), generalized_coordinates, create_graph=True)
         return tuple((sign * grad for sign, grad in zip(self.signs, grads)))
 
+
+class Hessian(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, source, positions, padding_mask):
+        """
+        Computes the Hessian using second derivatives of energy or first derivatives of forces.
+        Assumes:
+            - source: either energy (B, 1) or forces (B, N_max, 3)
+            - positions: (B, N_max, 3)
+        Returns:
+            - hessians: (B, 3N_max, 3N_max)
+        """
+        B, N, D = positions.shape
+
+        hessian_mask = self.expand_padding_mask_to_hessian_mask(padding_mask)
+
+        if source.ndim == 2 and source.shape[1] == 1:
+            # Case: source is energy (B, 1)
+            forces = self._forces_from_energy(source, positions)
+            return self._hessian_from_forces(forces, positions), hessian_mask
+        elif source.ndim == 3 and source.shape[2] == 3:
+            # Case: source is forces (B, N, 3)
+            return self._hessian_from_forces(source, positions), hessian_mask
+        else:
+            raise ValueError(f"Unsupported source shape: {source.shape}")
+
+    def _forces_from_energy(self, energy, positions):
+        return -torch.autograd.grad(energy.sum(), positions, create_graph=True)[0]
+
+    def _hessian_from_forces(self, force, positions):
+        force_flat = force.flatten(start_dim=1)
+        force_components = force_flat.unbind(dim=1)
+        return -torch.stack([
+            torch.autograd.grad(f.sum(), positions, create_graph=True)[0].flatten(start_dim=1)
+            for f in force_components
+        ], dim=1)
+
+    @staticmethod
+    def expand_padding_mask_to_hessian_mask(padding_mask):
+        """
+        Expand a (B, N) atom mask to a (B, 3N, 3N) Hessian mask.
+
+        Parameters:
+            padding_mask: Boolean tensor of shape (B, N_max)
+
+        Returns:
+            Boolean tensor of shape (B, 3N_max, 3N_max)
+        """
+        B, N = padding_mask.shape
+
+        expanded_mask = padding_mask.unsqueeze(-1).expand(-1, -1, 3).reshape(B, 3 * N)
+        mask_matrix = expanded_mask.unsqueeze(2) & expanded_mask.unsqueeze(1)  # (B, 3N, 3N)
+
+        return mask_matrix
+
+
+class HVPVector(torch.nn.Module):
+    def __init__(self, vector_type="random"):
+        super().__init__()
+        self.vector_type = vector_type
+
+    def forward(self, positions, nonblank):
+        """
+        positions: (B, N_max, 3)
+        nonblank: (B, N_max, 3), boolean mask
+        Returns: (B, N_max, 3) vector (zeroed on padded atoms)
+        """
+        num_atoms = nonblank.sum(dim=1, dtype=torch.int64)
+        N_max = nonblank.shape[1] # This is the maximum number of atoms across batches
+        vectors = torch.zeros(len(num_atoms), 3*N_max, dtype=positions.dtype, device=positions.device)
+
+        if self.vector_type == "random":
+            for i in range(len(num_atoms)): # For each system,
+                N = num_atoms[i]               # Get the number of atoms
+                # Create a vector with i.i.d. values from a Gaussian distribution with zero mean and unit deviation
+                values = torch.randn(3*N, dtype=positions.dtype, device=positions.device)
+                # Divide by its norm to get a unit vector (adds a 1/(3N) factor to the expected squared values)
+                values = values / torch.norm(values)
+                vectors[i][:3*N] = values
+
+        elif self.vector_type == "one-hot":
+            for i in range(len(num_atoms)): # For each system,
+                N = num_atoms[i]               # Get the number of atoms
+                column_idx = torch.randint(0,3*N, (1,)) # Create a random integer from 0 to 3N inclusive
+                vectors[i][column_idx] = 1.0            # Replace the 0.0 at the random index for 1.0
+
+        else:
+            raise ValueError(f"Unknown vector type {self.vector_type}")
+
+        vectors = vectors.view(len(num_atoms), N_max, 3)
+        return vectors
+
+
+class HVP(torch.nn.Module):
+    def forward(self, force, coordinates, vector, padding_mask):
+        """
+        source:       (B, N_max, 3)  force tensor
+        coordinates:  (B, N_max, 3), requires_grad=True
+        vector:       (B, N_max, 3), perturbation direction
+        padding_mask: (B, N_max, 3), HVP padding mask with 3N non-zero elements
+        Returns:      (B, N_max, 3), Hessian-vector product
+        """
+
+        # hessian_mask = self.expand_padding_mask_to_hessian_mask(padding_mask)
+        hvp = -torch.autograd.grad(force, coordinates, grad_outputs=vector, create_graph=True, retain_graph=True)[0]
+
+        return hvp, padding_mask.unsqueeze(-1).expand(-1, -1, 3)
+
+
+class TrueHVP(torch.nn.Module):
+    def forward(self, hessian, vector):
+        """
+        hessian: (B, 3N_max, 3N_max)
+        vector:  (B, N_max, 3)
+        Returns: (B, N_max, 3)
+        """
+        B, N, _ = vector.shape
+        vector_flat = vector.flatten(start_dim=1).unsqueeze(-1)  # (B, 3N, 1)
+        hvp_flat = torch.bmm(hessian, vector_flat).squeeze(-1)  # (B, 3N)
+        hvp = hvp_flat.view(B, N, 3)
+
+        return hvp  # (B, N, 3)
+    
+
 class StressForce(torch.nn.Module):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)


### PR DESCRIPTION
- Added the HessianNode, HVPVectorNode, HVPNode, and TrueHVPNode classes in hippynn/graphs/nodes/physics.py

- Added the Hessian, HVPVector, HVP, and TrueHVP modules in hippynn/layers/physics.py

- Modified the h6_pyanitools.py in hippynn/databases/ to be compatible with the Hessian matrices with shape (B, 3N, 3N). It now pads dimensions with sizes that are any multiple of N.

- Modified the WeightedMSELoss function in hippynn/layers/algebra.py so that it checks if the weights and the losses have the same shape and makes sure the mask dtype is equal to the unweighted loss dtype

- Added the training script for Hessian training (hessian_training.py) in the examples directory