### PR TITLE
Issue #127: Wrap Pytorch's Profiler API Calls  

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -21,6 +21,7 @@ Jan Janssen (LANL)
 Cagri Kaymak (LANL)
 Shuhao Zhang (CMU, LANL) - Batched Optimization routines
 Michael Chigaev (LANL, UC Berkeley)
+Andrew Trepagnier (ExxonMobil)
 
 
 Also thanks to testing and feedback from:

--- a/docs/source/examples/index.rst
+++ b/docs/source/examples/index.rst
@@ -12,6 +12,7 @@ For runnable example scripts, see `the examples at the hippynn github repository
     :maxdepth: 1
 
     minimal_workflow
+    profiling
     controller
     plotting
     predictor

--- a/docs/source/examples/minimal_workflow.rst
+++ b/docs/source/examples/minimal_workflow.rst
@@ -26,7 +26,7 @@ Now, let's create some nodes. We start with input nodes for the species and posi
     species = inputs.SpeciesNode(db_name="Z")
     positions = inputs.PositionsNode(db_name="R")
 
-The ``db_name`` is a key which will be used to find the corresponding information in the database we train or predict on.s
+The ``db_name`` is a key which will be used to find the corresponding information in the database we train or predict on.
 
 From here, we want to build a neural network. HIPNN has several hyperparameters that should be defined.
 

--- a/docs/source/examples/minimal_workflow.rst
+++ b/docs/source/examples/minimal_workflow.rst
@@ -158,6 +158,14 @@ Now that these are defined, we are good to begin training::
                     setup_params=experiment_params,
                     )
 
+
+The :func:`~hippynn.experiment.setup_and_train` function is a shortcut that calls 
+:func:`~hippynn.experiment.setup_training` followed by :func:`~hippynn.experiment.train_model`. 
+
+Sometimes it may be insightful to understand where potential performance bottlenecks exist in the training. To analyze this, the :func:`~hippynn.experiment.setup_and_profile` functions as 
+a drop-in replacement for the :func:`~hippynn.experiment.setup_and_train` function. The function accepts the same kwargs as :func:`~hippynn.experiment.setup_and_train`, so users may 
+quickly receive the robust feature offerings of the PyTorch profiler API with one function call.
+
 When training completes, we can use the model to make predictions.
 
 The simplest form will be to predict everything that the model needs to

--- a/docs/source/examples/profiling.rst
+++ b/docs/source/examples/profiling.rst
@@ -1,0 +1,52 @@
+Profiling 
+==============================
+
+The :func:`~hippynn.experiment.setup_and_profile` function is a drop-in replacement 
+for :func:`~hippynn.experiment.setup_and_train` that profiles your training loop 
+using PyTorch's built-in profiler.
+
+
+Simply swap ``setup_and_train`` with ``setup_and_profile``::
+
+    # Before:
+    from hippynn.experiment import setup_and_train
+
+    setup_and_train(
+        training_modules=training_modules,
+        database=database,
+        setup_params=experiment_params,
+    )
+
+    # After:
+    from hippynn.experiment import setup_and_profile
+
+    setup_and_profile(
+        training_modules=training_modules,
+        database=database,
+        setup_params=experiment_params,
+    )
+
+
+By default, the function runs only 3 epochs with 5 batches each, temporarily overriding 
+your ``max_epochs`` setting. This provides enough data to capture representative performance 
+patterns without the overhead of a full training run.
+
+The :func:`~hippynn.experiment.setup_and_profile` function accepts optional parameters 
+not available in ``setup_and_train`` to control the profiling behavior::
+
+    setup_and_profile(
+        training_modules=training_modules,
+        database=database,
+        setup_params=experiment_params,
+        profile_epochs=5,              # Optional: defaults to 3
+        batches_per_epoch=10,          # Optional: defaults to 5
+        trace_file="my_trace.json",    # Optional: defaults to "profile_trace.json"
+    )
+
+
+
+After profiling completes, a summary table is printed to the console showing the 
+most time-consuming operations. Additionally, a JSON trace file is saved to disk.
+
+To visualize the detailed timeline, open ``chrome://tracing`` in Google Chrome (must be chrome, not firefox or safari) 
+and load the JSON file. 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,6 +5,12 @@ Welcome to hippynn's documentation!
 
 We hope you enjoy your stay.
 
+Install hippynn with::
+
+        $ pip install hippynn
+
+(Or see :doc:`the installation documentation <installation/>`)
+
 .. include:: what_is_hippynn.rst
 
 .. toctree::
@@ -20,14 +26,17 @@ We hope you enjoy your stay.
     :maxdepth: 1
     :caption: User Guide:
 
+
     user_guide/features
     user_guide/concepts
     user_guide/databases
-    user_guide/loss_graph
     user_guide/units
+    user_guide/performance
     user_guide/ckernels
+    user_guide/loss_graph
     user_guide/settings
     user_guide/custom_nodes
+    
 
 
 .. toctree::

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -10,17 +10,20 @@ Requirements:
     * pytorch_ >= 2.0
     * numpy_
 
-Optional Dependencies:
+Recommended Optional Dependencies:
     * triton_ (recommended, for improved GPU performance)
     * numba_ (recommended, for improved CPU/GPU performance)
-    * cupy_ (alternative for accelerating GPU performance)
     * ASE_ (for usage with ase and other misc. features)
     * matplotlib_ (for plotting)
+    * h5py_ (for loading ani-h5 datasets)
+
+Other Optional Dependencies:
+    * cupy_ (alternative for accelerating GPU performance)
     * tqdm_ (for progress bars)
     * graphviz_ (for visualizing model graphs)
     * h5py_ (for loading ani-h5 datasets)
     * pytorch-lightning_ (for distributed training)
-    * opt_einsum_ (backend for accelerating some pytorch expressions)
+    * opt_einsum_ (backend for accelerating some pytorch operations)
 
 Interfacing codes:
     * ASE_
@@ -47,12 +50,29 @@ Interfacing codes:
 Installation Instructions
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-We recommend installation from source, although you can also get hippynn
-from conda and pypi, see below. A base installation of hippynn only requires
-pytorch (`installation instructions <pytorch_install_>`_) and
-numpy (`installation instructions <numpy_install_>`_).
-We recommend you install these first using your package manager of choice,
-then proceed to install hippynn.
+We recommend installing hippynn from source for the latest features as well as
+the example and test suites.
+
+
+Install hippynn using pip
+-------------------------
+Minimal Install using pip::
+
+    $ pip install hippynn
+
+All optional dependencies with pip::
+
+    $ pip install hippynn[full]
+
+On a recent mac with zsh instead of bash, this command must be escaped as::
+
+    % pip install hippynn\[full\]
+
+Install hippynn usnig conda
+---------------------------
+Install using conda::
+
+    $ conda install -c conda-forge hippynn
 
 
 Installing hippynn from source
@@ -105,25 +125,6 @@ On a recent mac with zsh instead of bash, this command must be escaped as::
 
     % pip install -e .\[full\]
 
-Install hippynn from Conda
---------------------------
-Install using conda::
-
-    $ conda install -c conda-forge hippynn
-
-Install hippynn from Pip
-------------------------
-Minimal Install using pip::
-
-    $ pip install hippynn
-
-All optional dependencies with pip::
-
-    $ pip install hippynn[full]
-
-On a recent mac with zsh instead of bash, this command must be escaped as::
-
-    % pip install hippynn\[full\]
 
 
 Note on installing cupy with conda
@@ -139,8 +140,8 @@ it from pypi. `Link to cupy installation instructions <cupy_install>`_
 Misc. Notes
 -----------
 
-- Install dependencies with pip from requirements.txt .
-- Install dependencies with conda from conda_requirements.txt .
+- You can also install dependencies with pip from requirements.txt .
+- Likewise with conda from conda_requirements.txt .
 - If you don't want pip to install them, conda install from file before installing ``hippynn``.
   You may want to use -c pytorch for the pytorch channel.
   For ase and cupy, you probably want to use -c conda-forge.

--- a/docs/source/user_guide/index.rst
+++ b/docs/source/user_guide/index.rst
@@ -1,7 +1,7 @@
 User Guide
 ==========
 
-Here we explain in how the library works.
+Here we explain how the library works.
 
 .. toctree::
     :maxdepth: 2
@@ -10,9 +10,11 @@ Here we explain in how the library works.
     features
     concepts
     databases
-    loss_graph
     units
+    performance
+    loss_graph
     ckernels
     settings
     custom_nodes
+    
 

--- a/docs/source/user_guide/performance.rst
+++ b/docs/source/user_guide/performance.rst
@@ -1,0 +1,50 @@
+Performance Tips
+=================
+
+Devices
+-------
+
+Using GPU resources will often speed up your training by more than a factor of ten.
+In general hippynn will aim to use the "cuda" device if available, and then fall back on the default pytorch device.
+To specify the device just pass a ``torch.device`` or compatible string to the :obj:`~hippynn.SetupParams` for a training run.
+This will take care of devices for training.
+At application time, if you're using a :func:`~hippynn.GraphModule`, :func:`~hippynn.Predictor`, :obj:`~hippynn.interfaces.ase_interface.HippynnCalculator`
+called ``obj``, then you can use ``obj.to(torch.device('cuda'))`` to move these objects to the GPU.
+
+Custom Kernels
+--------------
+
+hippynn has low-level implementations of the message passing functions for hip-nn.
+These are almost always helpful, but the exact degree depends, mostly on the size of the batches and the size of the network.
+In some cases with large models, there are multiple factors of improvement!
+These improve both the memory usage and speed for evaluating the network.
+You shouldn't need anything special for these to work on the GPU using triton, which is included with pytorch.
+On CPU they require installing numba.
+Custom kernels are described in more detail :doc:`here </user_guide/ckernels>` here.
+
+
+Profiling
+---------
+
+Especially during development, it can be very insightful to produce a trace of the CPU and GPU activities to find bottlenecks exist in the training.
+To analyze this, the :func:`~hippynn.experiment.setup_and_profile` functions as a drop-in replacement for the :func:`~hippynn.experiment.setup_and_train` function.
+The function accepts the same kwargs as :func:`~hippynn.experiment.setup_and_train`,
+so users may quickly receive the robust feature offerings of the PyTorch profiler API with one function call.
+This will output a json file which is compatible with the google chrome tracing tools.
+
+
+Scaling
+-------
+
+hipppynn models and loss functions are just pytorch modules,
+so you should be able to interface them to any accelerator package of choice.
+
+We recommend pytorch lightning for scaling.
+hippynn includes an interface to `Pytorch Lightning`_ for scaling to multiple GPUs or multiple nodes.
+See the :doc:`documentation page </examples/lightning>` for more infromation.
+
+There is legacy compatibility with the simple ``torch.nn.DataParallel`` by passing a list of device indices to
+the SetupParams for an experiment, but this is not a strong strategy for scaling training because it is limited by
+single-process CPU dispatch.
+
+.. _`Pytorch Lightning`: https://lightning.ai/docs/pytorch/stable/

--- a/examples/ani1x_training.py
+++ b/examples/ani1x_training.py
@@ -340,7 +340,7 @@ if __name__ == "__main__":
         "If tensor_order==0 then vanilla HIP-NN will "
         "be used regardless.",
     )
-    parser.add_argument("--tensor_order", type=int, default=0, help="tensor order $\ell$")
+    parser.add_argument("--tensor_order", type=int, default=0, help="tensor order $\\ell$")
     parser.add_argument("--tensor_factors", type=int, default=4, help="number of factors used (in HIP-HOP-NN only)")
     parser.add_argument("--atomization_consistent", type=bool, default=False)
 

--- a/examples/ani1x_training.py
+++ b/examples/ani1x_training.py
@@ -290,14 +290,24 @@ def main(args):
                 stopping_key=args.stopping_key,
             )
 
-            from hippynn.experiment import setup_and_train
-
-            setup_and_train(
-                training_modules=training_modules,
-                database=database,
-                setup_params=setup_params,
-            )
-
+            if args.profile:
+                from hippynn.experiment import setup_and_profile
+                
+                setup_and_profile(
+                    training_modules=training_modules,
+                    database=database,
+                    setup_params=setup_params,
+                    trace_file="profile_trace.json",
+                )
+            else:
+                from hippynn.experiment import setup_and_train
+                
+                setup_and_train(
+                    training_modules=training_modules,
+                    database=database,
+                    setup_params=setup_params,
+                )
+            
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
@@ -337,7 +347,7 @@ if __name__ == "__main__":
     parser.add_argument("--anidata_location", type=str, default="../../../datasets/ani1x_release/ani1x-release.h5")
     parser.add_argument("--qm_method", type=str, default="wb97x")
     parser.add_argument("--basis_set", type=str, default="dz")
-
+    parser.add_argument("--profile", action="store_true", help="Run profiler instead of full training")
     parser.add_argument("--force_training", action=BooleanOptionalAction, default=True, help="Use force training.")
 
     parser.add_argument("--batch_size", type=int, default=256)

--- a/hippynn/__init__.py
+++ b/hippynn/__init__.py
@@ -45,7 +45,7 @@ from .databases import Database, NPZDatabase, DirectoryDatabase
 # Training/testing routines
 from . import experiment
 from .experiment import setup_and_train, setup_and_profile, train_model, setup_training,\
-    test_model, load_model_from_cwd, load_checkpoint, load_checkpoint_from_cwd
+    test_model, load_model_from_cwd, load_checkpoint, load_checkpoint_from_cwd, SetupParams
 
 # Optional imports are dealt with in submodule
 from . import molecular_dynamics

--- a/hippynn/__init__.py
+++ b/hippynn/__init__.py
@@ -44,7 +44,7 @@ from .databases import Database, NPZDatabase, DirectoryDatabase
 
 # Training/testing routines
 from . import experiment
-from .experiment import setup_and_train, train_model, setup_training,\
+from .experiment import setup_and_train, setup_and_profile, train_model, setup_training,\
     test_model, load_model_from_cwd, load_checkpoint, load_checkpoint_from_cwd
 
 # Optional imports are dealt with in submodule

--- a/hippynn/experiment/__init__.py
+++ b/hippynn/experiment/__init__.py
@@ -11,10 +11,10 @@ from . import serialization
 from . import routines
 
 from .assembly import assemble_for_training
-from .routines import setup_and_train, setup_training, train_model, test_model, SetupParams
+from .routines import setup_and_train, setup_and_profile, setup_training, train_model, test_model, SetupParams
 from .serialization import load_checkpoint, load_checkpoint_from_cwd, load_model_from_cwd
 
-__all__ = ["assemble_for_training", "setup_and_train", "setup_training", "train_model", "test_model", "SetupParams",
+__all__ = ["assemble_for_training", "setup_and_train", "setup_and_profile", "setup_training", "train_model", "test_model", "SetupParams",
            "load_checkpoint", "load_checkpoint_from_cwd", "load_model_from_cwd"]
 
 try:

--- a/hippynn/experiment/routines.py
+++ b/hippynn/experiment/routines.py
@@ -237,7 +237,7 @@ def setup_and_profile(
     
     print(f"\nProfile saved to: {trace_file}")
     print("Open chrome://tracing in Chrome to visualize.")
-    print("For guidance viewing and interpreting results, see: https://hippynn.readthedocs.io/en/latest/profiling.html\n")
+    print("For guidance viewing and interpreting results, see: https://hippynn.readthedocs.io/en/latest/examples/profiling.html\n")
     print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=15))
     
     return trace_file

--- a/hippynn/experiment/routines.py
+++ b/hippynn/experiment/routines.py
@@ -181,7 +181,8 @@ def setup_and_profile(
 
     """
     # informs users that epoch number is overwritten temporarily 
-    if setup_params.max_epochs > profile_epochs:
+    max_epochs = setup_params.max_epochs
+    if max_epochs is not None and max_epochs > profile_epochs:
         print(f"Note: setup_and_profile uses {profile_epochs} epochs for profiling "
               f"(your setting of {setup_params.max_epochs} epochs is temporarily ignored). "
               f"This provides enough data to analyze performance without excessive runtime.")

--- a/hippynn/experiment/routines.py
+++ b/hippynn/experiment/routines.py
@@ -149,101 +149,6 @@ def setup_and_train(
     )
 
 
-def setup_and_profile(
-    training_modules: TrainingModules,
-    database: Database,
-    setup_params: SetupParams,
-    profile_epochs: int = 3,
-    batches_per_epoch: int = 5,
-    trace_file: str = "profile_trace.json",
-):
-    """
-    Profile training for performance analysis.
-
-    This function provides the same interface as :func:`setup_and_train`, but runs
-    a short training loop under a PyTorch profiler context and exports results
-    for visualization.
-
-    :param training_modules: see :func:`setup_training`
-    :param database: see :func:`train_model`
-    :param setup_params: see :func:`setup_training`
-    :param profile_epochs: Number of epochs to profile (default: 3)
-    :param batches_per_epoch: Number of batches per epoch to profile (default: 5)
-    :param trace_file: Output path for Chrome trace file (default: "profile_trace.json")
-
-    :return: Path to the saved trace file
-
-    .. Note::
-        The setup_params max_epochs is ignored; profiling uses profile_epochs instead.
-
-    .. Note::
-        Open chrome://tracing in Chrome browser to visualize the trace file.
-
-    """
-    # informs users that epoch number is overwritten temporarily 
-    max_epochs = setup_params.max_epochs
-    if max_epochs is not None and max_epochs > profile_epochs:
-        print(f"Note: setup_and_profile uses {profile_epochs} epochs for profiling "
-              f"(your setting of {setup_params.max_epochs} epochs is temporarily ignored). "
-              f"This provides enough data to analyze performance without excessive runtime.")
-    
-    
-    training_modules, controller, metric_tracker = setup_training(
-        training_modules=training_modules,
-        setup_params=setup_params,
-    )
-    
-    model, loss, evaluator = training_modules
-    
-    
-    if not database.splitting_completed:
-        raise ValueError("Database has not been split. Please split the database before profiling.")
-    database.inputs = evaluator.db_info['inputs']
-    database.targets = evaluator.db_info['targets']
-    
-    n_inputs = len(database.inputs)
-    n_targets = len(database.targets)
-    device = evaluator.model_device
-    optimizer = controller.optimizer
-    step_function = get_step_function(optimizer)
-    
-    use_cuda = (device.type == "cuda")
-    
-    print(f"Profiling {profile_epochs} epochs x {batches_per_epoch} batches on {device}")
-    
-    with torch.autograd.profiler.profile(
-        enabled=True,
-        use_cuda=use_cuda,
-        record_shapes=True,
-        with_stack=True,
-    ) as prof:
-        
-        for epoch in range(profile_epochs):
-            model.train()
-            train_gen = database.make_generator("train", "train", batch_size=controller.batch_size)
-            
-            for batch_idx, batch in enumerate(train_gen):
-                if batch_idx >= batches_per_epoch:
-                    break
-                
-                batch = [item.to(device=device, non_blocking=True) for item in batch]
-                batch_inputs = batch[:n_inputs]
-                batch_targets = batch[-n_targets:]
-                batch_targets = [x.requires_grad_(False) for x in batch_targets]
-                
-                batch_model_outputs = step_function(optimizer, model, loss, batch_inputs, batch_targets)
-                del batch_model_outputs
-    
-    prof.export_chrome_trace(trace_file)
-    
-    print(f"\nProfile saved to: {trace_file}")
-    print("Open chrome://tracing in Chrome to visualize.")
-    print("For guidance viewing and interpreting results, see: https://hippynn.readthedocs.io/en/latest/examples/profiling.html\n")
-    print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=15))
-    
-    return trace_file
-
-
 def setup_training(
     training_modules: TrainingModules,
     setup_params: SetupParams,
@@ -663,3 +568,111 @@ def training_loop(
         epoch += 1
 
     return metric_tracker
+
+
+
+def setup_and_profile(
+    training_modules: TrainingModules,
+    database: Database,
+    setup_params: SetupParams,
+    profile_epochs: int = 3,
+    batches_per_epoch: int = 3,
+    record_shapes=False,
+    with_stack=False,
+    with_modules=False,
+    with_flops=False,
+    trace_file: str = "profile_trace.json",
+):
+    """
+    Profile training for performance analysis.
+
+    For documentation information, see :doc:`/user_guide/performance`
+
+    This function provides the same interface as :func:`setup_and_train`, but runs
+    a short training loop under a PyTorch profiler context and exports results
+    for visualization.
+
+    :param training_modules: see :func:`setup_training`
+    :param database: see :func:`train_model`
+    :param setup_params: see :func:`setup_training`
+    :param profile_epochs: Number of epochs to profile (default: 3)
+    :param batches_per_epoch: Number of batches per epoch to profile (default: 5)
+    :param trace_file: Output path for Chrome trace file (default: "profile_trace.json")
+
+    :return: Path to the saved trace file
+
+    .. Note::
+        The setup_params max_epochs is ignored; profiling uses profile_epochs instead.
+
+    .. Note::
+        Open chrome://tracing in Chrome browser to visualize the trace file.
+
+    """
+    # informs users that epoch number is overwritten temporarily 
+    max_epochs = setup_params.max_epochs
+    if max_epochs is not None and max_epochs > profile_epochs:
+        print(f"Note: setup_and_profile uses {profile_epochs} epochs for profiling "
+              f"(your setting of {setup_params.max_epochs} epochs is temporarily ignored). "
+              f"This provides enough data to analyze performance without excessive runtime.")
+    
+    
+    training_modules, controller, metric_tracker = setup_training(
+        training_modules=training_modules,
+        setup_params=setup_params,
+    )
+    
+    model, loss, evaluator = training_modules
+    
+    if not database.splitting_completed:
+        raise ValueError("Database has not been split. Please split the database before profiling.")
+    database.inputs = evaluator.db_info['inputs']
+    database.targets = evaluator.db_info['targets']
+    
+    n_inputs = len(database.inputs)
+    n_targets = len(database.targets)
+    device = evaluator.model_device
+    optimizer = controller.optimizer
+    step_function = get_step_function(optimizer)
+    
+    use_cuda = (device.type == "cuda")
+    train_gen = database.make_generator("train", "train", batch_size=controller.batch_size)
+    model.train()
+
+    def step_once(batch):
+        batch = [item.to(device=device, non_blocking=True) for item in batch]
+        batch_inputs = batch[:n_inputs]
+        batch_targets = batch[-n_targets:]
+        batch_targets = [x.requires_grad_(False) for x in batch_targets]
+        batch_model_outputs = step_function(optimizer, model, loss, batch_inputs, batch_targets)
+        del batch_model_outputs
+    
+    print("Running test batch.")    
+    # We run the test batch so that all necessary code is imported before tracing.
+    step_once(next(iter(train_gen)))
+    
+    print(f"Profiling {profile_epochs} epochs x {batches_per_epoch} batches on {device}")
+    
+    with torch.autograd.profiler.profile(
+        enabled=True,
+        use_cuda=use_cuda,
+        record_shapes=record_shapes,
+        with_stack=with_stack,
+        with_modules=with_modules,
+        with_flops=with_flops,
+    ) as prof:
+        
+        for epoch in tools.progress_bar(range(profile_epochs), desc="Profiling Epochs", unit="epoch"):
+            
+            for batch_idx, batch in tools.progress_bar(enumerate(train_gen), desc="Batches", unit="batch"):
+                if batch_idx >= batches_per_epoch:
+                    break
+                step_once(batch)
+    
+    prof.export_chrome_trace(trace_file)
+    
+    print(f"\nProfile saved to: {trace_file}")
+    print("Open chrome://tracing in Chrome to visualize.")
+    print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=15))
+    
+    return trace_file
+

--- a/hippynn/experiment/routines.py
+++ b/hippynn/experiment/routines.py
@@ -149,6 +149,100 @@ def setup_and_train(
     )
 
 
+def setup_and_profile(
+    training_modules: TrainingModules,
+    database: Database,
+    setup_params: SetupParams,
+    profile_epochs: int = 3,
+    batches_per_epoch: int = 5,
+    trace_file: str = "profile_trace.json",
+):
+    """
+    Profile training for performance analysis.
+
+    This function provides the same interface as :func:`setup_and_train`, but runs
+    a short training loop under a PyTorch profiler context and exports results
+    for visualization.
+
+    :param training_modules: see :func:`setup_training`
+    :param database: see :func:`train_model`
+    :param setup_params: see :func:`setup_training`
+    :param profile_epochs: Number of epochs to profile (default: 3)
+    :param batches_per_epoch: Number of batches per epoch to profile (default: 5)
+    :param trace_file: Output path for Chrome trace file (default: "profile_trace.json")
+
+    :return: Path to the saved trace file
+
+    .. Note::
+        The setup_params max_epochs is ignored; profiling uses profile_epochs instead.
+
+    .. Note::
+        Open chrome://tracing in Chrome browser to visualize the trace file.
+
+    """
+    # informs users that epoch number is overwritten temporarily 
+    if setup_params.max_epochs > profile_epochs:
+        print(f"Note: setup_and_profile uses {profile_epochs} epochs for profiling "
+              f"(your setting of {setup_params.max_epochs} epochs is temporarily ignored). "
+              f"This provides enough data to analyze performance without excessive runtime.")
+    
+    
+    training_modules, controller, metric_tracker = setup_training(
+        training_modules=training_modules,
+        setup_params=setup_params,
+    )
+    
+    model, loss, evaluator = training_modules
+    
+    
+    if not database.splitting_completed:
+        raise ValueError("Database has not been split. Please split the database before profiling.")
+    database.inputs = evaluator.db_info['inputs']
+    database.targets = evaluator.db_info['targets']
+    
+    n_inputs = len(database.inputs)
+    n_targets = len(database.targets)
+    device = evaluator.model_device
+    optimizer = controller.optimizer
+    step_function = get_step_function(optimizer)
+    
+    use_cuda = (device.type == "cuda")
+    
+    print(f"Profiling {profile_epochs} epochs x {batches_per_epoch} batches on {device}")
+    
+    with torch.autograd.profiler.profile(
+        enabled=True,
+        use_cuda=use_cuda,
+        record_shapes=True,
+        with_stack=True,
+    ) as prof:
+        
+        for epoch in range(profile_epochs):
+            model.train()
+            train_gen = database.make_generator("train", "train", batch_size=controller.batch_size)
+            
+            for batch_idx, batch in enumerate(train_gen):
+                if batch_idx >= batches_per_epoch:
+                    break
+                
+                batch = [item.to(device=device, non_blocking=True) for item in batch]
+                batch_inputs = batch[:n_inputs]
+                batch_targets = batch[-n_targets:]
+                batch_targets = [x.requires_grad_(False) for x in batch_targets]
+                
+                batch_model_outputs = step_function(optimizer, model, loss, batch_inputs, batch_targets)
+                del batch_model_outputs
+    
+    prof.export_chrome_trace(trace_file)
+    
+    print(f"\nProfile saved to: {trace_file}")
+    print("Open chrome://tracing in Chrome to visualize.")
+    print("For guidance viewing and interpreting results, see: https://hippynn.readthedocs.io/en/latest/profiling.html\n")
+    print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=15))
+    
+    return trace_file
+
+
 def setup_training(
     training_modules: TrainingModules,
     setup_params: SetupParams,

--- a/hippynn/tools.py
+++ b/hippynn/tools.py
@@ -132,7 +132,7 @@ def param_print(module):
 
 
 def device_fallback():
-    device = (torch.cuda.is_available() and torch.device(torch.cuda.current_device())) or torch.device("cpu")
+    device = (torch.cuda.is_available() and torch.device(torch.cuda.current_device())) or torch.get_default_device()
     print("Device was not specified. Attempting to default to device:", device)
     device = torch.device(device.type)
     return device


### PR DESCRIPTION
# Issue #127: Wrap Pytorch's Profiler API Calls  

This report proposes the addition of a new profiling function, `setup_and_profile()` to address [issue #127]([Link](https://github.com/lanl/hippynn/issues/127)) in the [Los Alamos HIPPYNN Library]([Link](https://lanl.github.io/hippynn/)). This long-awaited tooling enhancement aims to abstract away the complexity of working directly with the PyTorch Profiler API. 


## Summary of `setup_and_profile()`

The addition of the `setup_and_profile()` function provides a drop-in replacement for the pre-existing `setup_and_train()` function, allowing users to analyze system performance characteristics of HIPPYNN training procedures in real-world settings.

### Example: Barebones.py 

```python=
# ... Define hyperparameters for network and model as usual...

from hippynn.pretraining import hierarchical_energy_initialization
        hierarchical_energy_initialization(henergy, database, trainable_after=False)

        experiment_params = hippynn.experiment.SetupParams(
            stopping_key="MSE",
            batch_size=12,
            optimizer=torch.optim.Adam,
            max_epochs=100,
            learning_rate=0.001,
        )
        
    
        # Replace setup_and_train() with setup_and_profile()
        hippynn.experiment.setup_and_profile( 
            training_modules=training_modules,
            database=database,
            setup_params=experiment_params,
            
            
            profile_epochs=3, # Optional
            batches_per_epoch=5, # Optional
            trace_file="profile_trace.json", # Optional
        )
```


The code snippit above is equivalent to the typical barebones.py hippynn implementation, with an exception to the newly proposed `setup_and_profile()` function replacing the `setup_and_train()`. 

Three new optional arguments are provided for users seeking more control over profiling behavior. By default, `setup_and_profile()` samples training using the QM7 dataset over three epochs with five batches per epoch. Users may also specify a custom name for the exported JSON trace file.



### Motivation

The `torch.autograd.profiler()` context manager is a powerful feature of the PyTorch profiler API; however, implementing this feature can be quite advanced for less pytorch-savvy users. In line with the HIPPYNN design philosophy, the `setup_and_profile()` provides a new tooling enhancement that aims to abstracts out the complexities of dealing with the profiler API by wrapping it in a straight forward, single-function call. 


### Routines.py: What is wrapped

The `setup_and_profile()` function encapsulates the complexity of PyTorch's profiling API by combining several key components:

**Setup Dispatch:**
Before profiling begins, `setup_and_profile()` dispatches to the same `setup_training()` function used by `setup_and_train()`:

```python=
training_modules, controller, metric_tracker = setup_training(
    training_modules=training_modules,
    setup_params=setup_params,
)
```

**Profiler Context Manager:**
The training loop runs inside a `torch.autograd.profiler.profile()` context manager, which records timing data for every operation:

```python=
with torch.autograd.profiler.profile(
    enabled=True,
    use_cuda=use_cuda,
    record_shapes=True,
    with_stack=True,
) as prof:
    # ... training loop runs here ...

```

**Training Loop:**
Inside the context manager, a simplified loop structure mirrors hippynn's `training_loop()`:

```python=
for epoch in range(profile_epochs):
    model.train()
    train_gen = database.make_generator("train", "train", batch_size=controller.batch_size)
    
    for batch_idx, batch in enumerate(train_gen):
        if batch_idx >= batches_per_epoch:
            break
        
        
        batch = [item.to(device=device, non_blocking=True) for item in batch]
        batch_inputs = batch[:n_inputs]
        batch_targets = batch[-n_targets:]
        
        # Execute forward/backward pass via step function
        batch_model_outputs = step_function(optimizer, model, loss, batch_inputs, batch_targets)
```
The outer loop runs for the specified number of profiling epochs, while the inner loop processes a limited number of batches per epoch. This keeps the profiling run short while still capturing representative performance behavior.

**Chrome Trace Export:**
Collected profiling data is exported:

```python=
prof.export_chrome_trace(trace_file)
print(prof.key_averages().table(sort_by="cpu_time_total", row_limit=15))
```
This gives users the console summary and a JSON trace file for detailed visualization in Chrome's tracing tool.


### Links

[Issue #127](https://github.com/lanl/hippynn/issues/127)
