### PR TITLE
Quality of life: three bugfixes + HuberLoss node

### DIFF
--- a/hippynn/databases/h5_pyanitools.py
+++ b/hippynn/databases/h5_pyanitools.py
@@ -89,7 +89,7 @@ class PyAniMethods:
         # the algorithm would treat the coordinates as needing padding.
         if n_atoms < 7:
             try:
-                return self.determine_key_structure(batch_list[1:], species_key=species_key)
+                return self.determine_key_structure(batch_list[1:], sys_count, n_atoms_max, species_key=species_key)
             except RecursionError as re:
                 msg = "Automatic detection of arrays is only compatible with datasets of at least 6 atoms -- this is not supported."
                 raise ValueError(msg) from re

--- a/hippynn/experiment/controllers.py
+++ b/hippynn/experiment/controllers.py
@@ -235,7 +235,7 @@ class RaiseBatchSizeOnPlateau(ReduceLROnPlateau):
 
     def load_state_dict(self, state_dict):
         self.boredom = state_dict["boredom"]
-        self.best_metric = state_dict["boredom"]
+        self.best_metric = state_dict["best_metric"]
         self.inner.load_state_dict(state_dict["inner"])
         self.last_epoch = state_dict["last_epoch"]
 

--- a/hippynn/graphs/nodes/loss.py
+++ b/hippynn/graphs/nodes/loss.py
@@ -156,6 +156,10 @@ class MAELoss(_BaseCompareLoss, op=torch.nn.functional.l1_loss):
     pass
 
 
+class HuberLoss(_BaseCompareLoss, op=torch.nn.functional.huber_loss):
+    pass
+
+
 class _LPReg(AutoKw, SingleNode):
     index_state = IdxType.Scalar
     auto_module_class = reg_modules.LPReg

--- a/hippynn/tools.py
+++ b/hippynn/tools.py
@@ -132,7 +132,12 @@ def param_print(module):
 
 
 def device_fallback():
-    device = (torch.cuda.is_available() and torch.device(torch.cuda.current_device())) or torch.get_default_device()
+    if torch.cuda.is_available():
+        device = torch.device(torch.cuda.current_device())
+    elif hasattr(torch, "get_default_device"):
+        device = torch.get_default_device()
+    else:
+        device = torch.device("cpu")
     print("Device was not specified. Attempting to default to device:", device)
     device = torch.device(device.type)
     return device


### PR DESCRIPTION
Hi — I've been using HIPPYNN for MLIP research on electrochemical
interfaces, and ran into a few small things while doing production
training and loading data. Talked with Nicholas and Ben at LANL last
week and they suggested I start raising PRs — easier ones first.
Bundling these four independent fixes as one quality-of-life PR.

Four commits, each in its own file:

**1. controllers.py** — `RaiseBatchSizeOnPlateau.load_state_dict` was
reading `state_dict["boredom"]` into `self.best_metric` instead of
`state_dict["best_metric"]`. Save side stores it correctly, just the
load side had the wrong key. I hit this doing warm-restart training.

**2. h5_pyanitools.py** — `determine_key_structure` recurses when
`n_atoms < 7`, but the recursive call was missing `sys_count` and
`n_atoms_max` args. TypeErrors instead of recursing. I hit this when
I was training on small molecules only. Moved to mixed data later so
doesn't happen now, but still a real bug for any mixed dataset where
the first batch happens to be small.

**3. loss.py** — adds `HuberLoss` node, same pattern as `MSELoss` /
`MAELoss` — wraps `torch.nn.functional.huber_loss`. Been using this
locally for outlier-robust energy/force losses (forces on
near-collision configs blow up MSE).

**4. tools.py** — `device_fallback()` was calling
`torch.get_default_device()`, which was only added in PyTorch 2.3.
`pyproject.toml` allows `torch>2.0`, so on a CPU-only setup with
PyTorch < 2.3 the import AttributeErrors. I'm on 2.2.2 and hit it.
Rewrites as if/elif/else with a hasattr guard.

---

Tested locally on macOS, PyTorch 2.2.2: 40 pass, 11 skipped (data files
unavailable), 2 fail. The 2 failures are pre-existing on pristine
`development` (`torch.mps.device_count` AttributeError and a custom-
kernel registry issue — both unrelated to these changes).
`test_build_training_modules` was failing on pristine `development`
because of fix 4's bug; it passes with this PR.

Each commit is independent. Happy to split into separate PRs if you'd
prefer that.

Thanks!
