### PR TITLE
Add WeightedHuberLoss and per-loss delta for Huber losses

### DIFF
--- a/hippynn/graphs/nodes/loss.py
+++ b/hippynn/graphs/nodes/loss.py
@@ -1,8 +1,6 @@
 """
 Nodes for constructing loss functions.
 """
-import functools
-
 import torch
 import torch.nn.functional
 
@@ -140,24 +138,21 @@ class WeightedMAELoss(_WeightedCompareLoss):
     _classname = "WeightedMAE"
     torch_module = algebra_modules.WeightedMAELoss()
 
-class WeightedHuberLoss(_WeightedCompareLoss):
+class WeightedHuberLoss(AutoKw, SingleNode):
     _classname = "WeightedHuber"
-    torch_module = algebra_modules.WeightedHuberLoss()
+    index_state = IdxType.Scalar
+    auto_module_class = algebra_modules.WeightedHuberLoss
+    auto_module_kwargs = "delta",
 
-    def __init__(self, predicted, true, weight, delta=None):
-        if delta is None:
-            super().__init__(predicted, true, weight)
-            return
-        # A per-instance delta needs its own layer module; the class-level one is shared.
-        name = "{}(delta={},{},{},{})".format(self._classname, delta, predicted.name, true.name, weight.name)
+    def __init__(self, predicted, true, weight, delta=1.0, module="auto"):
+        name = "{}({},{},{})".format(self._classname, predicted.name, true.name, weight.name)
         predicted, true, weight = elementwise_compare_reduce(predicted, true, weight)
-        module = algebra_modules.WeightedHuberLoss(delta=delta)
-        SingleNode.__init__(self, name, (predicted, true, weight), module=module)
+        super().__init__(name, (predicted, true, weight), module=module, delta=delta)
 
     @classmethod
-    def of_node(cls, node, weight, delta=None):
+    def of_node(cls, node, weight, delta=1.0):
         """
-        Same as _WeightedCompareLoss.of_node, plus an optional huber delta.
+        Same as _WeightedCompareLoss.of_node, plus the huber delta.
         """
         node = node.main_output
 
@@ -191,23 +186,21 @@ class MAELoss(_BaseCompareLoss, op=torch.nn.functional.l1_loss):
     pass
 
 
-class HuberLoss(_BaseCompareLoss, op=torch.nn.functional.huber_loss):
-    def __init__(self, predicted, true, delta=None):
-        if delta is None:
-            super().__init__(predicted, true)
-            return
-        # The class-level module is baked with torch's default delta of 1.0;
-        # any other delta needs its own module instance.
+class HuberLoss(AutoKw, SingleNode):
+    _classname = "huber_loss"
+    index_state = IdxType.Scalar
+    auto_module_class = torch.nn.HuberLoss
+    auto_module_kwargs = "delta",
+
+    def __init__(self, predicted, true, delta=1.0, module="auto"):
         predicted = predicted.main_output
         true = true.main_output
-        name = "{}(delta={},{},{})".format(self._classname, delta, predicted.name, true.name)
+        name = "{}({},{})".format(self._classname, predicted.name, true.name)
         predicted, true = elementwise_compare_reduce(predicted, true)
-        op = functools.partial(torch.nn.functional.huber_loss, delta=float(delta))
-        op.__name__ = "huber_loss"
-        SingleNode.__init__(self, name, (predicted, true), module=algebra_modules.LambdaModule(op))
+        super().__init__(name, (predicted, true), module=module, delta=delta)
 
     @classmethod
-    def of_node(cls, node, delta=None):
+    def of_node(cls, node, delta=1.0):
         node = node.main_output
         return cls(node.pred, node.true, delta=delta)
 

--- a/hippynn/graphs/nodes/loss.py
+++ b/hippynn/graphs/nodes/loss.py
@@ -1,6 +1,8 @@
 """
 Nodes for constructing loss functions.
 """
+import functools
+
 import torch
 import torch.nn.functional
 
@@ -138,6 +140,39 @@ class WeightedMAELoss(_WeightedCompareLoss):
     _classname = "WeightedMAE"
     torch_module = algebra_modules.WeightedMAELoss()
 
+class WeightedHuberLoss(_WeightedCompareLoss):
+    _classname = "WeightedHuber"
+    torch_module = algebra_modules.WeightedHuberLoss()
+
+    def __init__(self, predicted, true, weight, delta=None):
+        if delta is None:
+            super().__init__(predicted, true, weight)
+            return
+        # A per-instance delta needs its own layer module; the class-level one is shared.
+        name = "{}(delta={},{},{},{})".format(self._classname, delta, predicted.name, true.name, weight.name)
+        predicted, true, weight = elementwise_compare_reduce(predicted, true, weight)
+        module = algebra_modules.WeightedHuberLoss(delta=delta)
+        SingleNode.__init__(self, name, (predicted, true, weight), module=module)
+
+    @classmethod
+    def of_node(cls, node, weight, delta=None):
+        """
+        Same as _WeightedCompareLoss.of_node, plus an optional huber delta.
+        """
+        node = node.main_output
+
+        if isinstance(weight, str):
+            index_state = db_state_of(node.index_state)
+            weight = InputNode(db_name=weight, index_state=index_state)
+
+        if not weight.is_in_loss_graph():
+            if isinstance(weight, InputNode):
+                weight = weight.true
+            else:
+                weight = weight.pred
+
+        return cls(node.pred, node.true, weight, delta=delta)
+
 class RsqMod(torch.nn.Module):
     def forward(self, predicted, true):
         return 1 - (torch.mean(torch.pow(predicted - true, 2)) / true.var())
@@ -157,7 +192,24 @@ class MAELoss(_BaseCompareLoss, op=torch.nn.functional.l1_loss):
 
 
 class HuberLoss(_BaseCompareLoss, op=torch.nn.functional.huber_loss):
-    pass
+    def __init__(self, predicted, true, delta=None):
+        if delta is None:
+            super().__init__(predicted, true)
+            return
+        # The class-level module is baked with torch's default delta of 1.0;
+        # any other delta needs its own module instance.
+        predicted = predicted.main_output
+        true = true.main_output
+        name = "{}(delta={},{},{})".format(self._classname, delta, predicted.name, true.name)
+        predicted, true = elementwise_compare_reduce(predicted, true)
+        op = functools.partial(torch.nn.functional.huber_loss, delta=float(delta))
+        op.__name__ = "huber_loss"
+        SingleNode.__init__(self, name, (predicted, true), module=algebra_modules.LambdaModule(op))
+
+    @classmethod
+    def of_node(cls, node, delta=None):
+        node = node.main_output
+        return cls(node.pred, node.true, delta=delta)
 
 
 class _LPReg(AutoKw, SingleNode):

--- a/hippynn/layers/algebra.py
+++ b/hippynn/layers/algebra.py
@@ -47,6 +47,20 @@ class WeightedMAELoss(_WeightedLoss):
     loss_func = staticmethod(torch.nn.functional.l1_loss)
 
 
+class WeightedHuberLoss(_WeightedLoss):
+    """Weighted Huber loss. ``delta`` sets the quadratic-to-linear transition point."""
+
+    def __init__(self, delta=1.0):
+        super().__init__()
+        self.delta = float(delta)
+
+    def loss_func(self, pred, true, reduction):
+        return torch.nn.functional.huber_loss(pred, true, reduction=reduction, delta=self.delta)
+
+    def extra_repr(self):
+        return f"delta={self.delta}"
+
+
 class AtLeast2D(torch.nn.Module):
     def forward(self, item):
         if item.ndimension() == 1:

--- a/hippynn/layers/algebra.py
+++ b/hippynn/layers/algebra.py
@@ -52,13 +52,19 @@ class WeightedHuberLoss(_WeightedLoss):
 
     def __init__(self, delta=1.0):
         super().__init__()
-        self.delta = float(delta)
+        self.huber = torch.nn.HuberLoss(reduction="none", delta=delta)
 
-    def loss_func(self, pred, true, reduction):
-        return torch.nn.functional.huber_loss(pred, true, reduction=reduction, delta=self.delta)
+    def forward(self, pred, true, weights):
+        unweighted_loss = self.huber(pred, true)
+        assert weights.shape == unweighted_loss.shape, (
+            f"Shape mismatch: weights {weights.shape}, loss {unweighted_loss.shape}"
+        )
 
-    def extra_repr(self):
-        return f"delta={self.delta}"
+        weights = weights.to(dtype=unweighted_loss.dtype)
+
+        normalized_weights = weights/torch.mean(weights)
+        weighted_loss = (normalized_weights*unweighted_loss).mean()
+        return weighted_loss
 
 
 class AtLeast2D(torch.nn.Module):

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -84,3 +84,66 @@ def test_weighted_loss_string(energy_force_nodes):
     henergy, forces = energy_force_nodes
     mse_energy_weighted2 = loss.WeightedMSELoss.of_node(henergy, "en_mask")
     mse_force_weighted2 = loss.WeightedMSELoss.of_node(forces, "f_mask")
+
+
+def test_weighted_huber_layer():
+    import torch
+    from hippynn.layers.algebra import WeightedHuberLoss
+
+    pred = torch.tensor([0.0, 1.0, 4.0, -3.0])
+    true = torch.tensor([0.5, 1.0, 0.0, 0.0])
+    weights = torch.tensor([1.0, 2.0, 0.5, 1.5])
+
+    elementwise = torch.nn.functional.huber_loss(pred, true, reduction="none")
+    expected = ((weights / weights.mean()) * elementwise).mean()
+    assert torch.allclose(WeightedHuberLoss()(pred, true, weights), expected)
+
+    # Uniform weights reduce to the plain huber loss.
+    uniform = torch.ones_like(pred)
+    plain = torch.nn.functional.huber_loss(pred, true)
+    assert torch.allclose(WeightedHuberLoss()(pred, true, uniform), plain)
+
+    # delta must reach the computation: a residual of 2 is in the linear
+    # regime for delta=1 (2 - 0.5 = 1.5) but quadratic for delta=5 (2**2 / 2 = 2.0).
+    pred2 = torch.full((4,), 2.0)
+    true2 = torch.zeros(4)
+    assert torch.allclose(WeightedHuberLoss()(pred2, true2, uniform), torch.tensor(1.5))
+    assert torch.allclose(WeightedHuberLoss(delta=5.0)(pred2, true2, uniform), torch.tensor(2.0))
+
+
+def test_huber_node_delta():
+    import torch
+    from hippynn.graphs import GraphModule
+    from hippynn.graphs.nodes import inputs, loss
+
+    a = inputs.InputNode(db_name="a")
+    default = loss.HuberLoss.of_node(a)
+    wide = loss.HuberLoss.of_node(a, delta=5.0)
+    g = GraphModule([a.pred, a.true], [default, wide])
+
+    predicted = torch.full((4, 1), 2.0)
+    true = torch.zeros(4, 1)
+    out_default, out_wide = g(predicted, true)
+    assert out_default.item() == pytest.approx(1.5)
+    assert out_wide.item() == pytest.approx(2.0)
+
+    repr(g)  # the delta-carrying module must stay printable
+
+
+def test_weighted_huber_node():
+    import torch
+    from hippynn.graphs import GraphModule
+    from hippynn.graphs.nodes import inputs, loss
+
+    a = inputs.InputNode(db_name="a")
+    w = inputs.InputNode(db_name="w")
+    weighted = loss.WeightedHuberLoss.of_node(a, w, delta=2.0)
+    g = GraphModule([a.pred, a.true, w.true], [weighted])
+
+    predicted = torch.tensor([[3.0], [0.5], [-4.0], [1.0]])
+    true = torch.zeros(4, 1)
+    weights = torch.tensor([[1.0], [3.0], [0.5], [2.0]])
+
+    elementwise = torch.nn.functional.huber_loss(predicted, true, reduction="none", delta=2.0)
+    expected = ((weights / weights.mean()) * elementwise).mean()
+    assert torch.allclose(g(predicted, true, weights)[0], expected)

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -86,64 +86,23 @@ def test_weighted_loss_string(energy_force_nodes):
     mse_force_weighted2 = loss.WeightedMSELoss.of_node(forces, "f_mask")
 
 
-def test_weighted_huber_layer():
-    import torch
-    from hippynn.layers.algebra import WeightedHuberLoss
-
-    pred = torch.tensor([0.0, 1.0, 4.0, -3.0])
-    true = torch.tensor([0.5, 1.0, 0.0, 0.0])
-    weights = torch.tensor([1.0, 2.0, 0.5, 1.5])
-
-    elementwise = torch.nn.functional.huber_loss(pred, true, reduction="none")
-    expected = ((weights / weights.mean()) * elementwise).mean()
-    assert torch.allclose(WeightedHuberLoss()(pred, true, weights), expected)
-
-    # Uniform weights reduce to the plain huber loss.
-    uniform = torch.ones_like(pred)
-    plain = torch.nn.functional.huber_loss(pred, true)
-    assert torch.allclose(WeightedHuberLoss()(pred, true, uniform), plain)
-
-    # delta must reach the computation: a residual of 2 is in the linear
-    # regime for delta=1 (2 - 0.5 = 1.5) but quadratic for delta=5 (2**2 / 2 = 2.0).
-    pred2 = torch.full((4,), 2.0)
-    true2 = torch.zeros(4)
-    assert torch.allclose(WeightedHuberLoss()(pred2, true2, uniform), torch.tensor(1.5))
-    assert torch.allclose(WeightedHuberLoss(delta=5.0)(pred2, true2, uniform), torch.tensor(2.0))
-
-
-def test_huber_node_delta():
-    import torch
-    from hippynn.graphs import GraphModule
-    from hippynn.graphs.nodes import inputs, loss
-
-    a = inputs.InputNode(db_name="a")
-    default = loss.HuberLoss.of_node(a)
-    wide = loss.HuberLoss.of_node(a, delta=5.0)
-    g = GraphModule([a.pred, a.true], [default, wide])
-
-    predicted = torch.full((4, 1), 2.0)
-    true = torch.zeros(4, 1)
-    out_default, out_wide = g(predicted, true)
-    assert out_default.item() == pytest.approx(1.5)
-    assert out_wide.item() == pytest.approx(2.0)
-
-    repr(g)  # the delta-carrying module must stay printable
-
-
-def test_weighted_huber_node():
+def test_huber_losses():
     import torch
     from hippynn.graphs import GraphModule
     from hippynn.graphs.nodes import inputs, loss
 
     a = inputs.InputNode(db_name="a")
     w = inputs.InputNode(db_name="w")
-    weighted = loss.WeightedHuberLoss.of_node(a, w, delta=2.0)
-    g = GraphModule([a.pred, a.true, w.true], [weighted])
+    plain = loss.HuberLoss.of_node(a)
+    wide = loss.WeightedHuberLoss.of_node(a, w, delta=5.0)
+    g = GraphModule([a.pred, a.true, w.true], [plain, wide])
 
-    predicted = torch.tensor([[3.0], [0.5], [-4.0], [1.0]])
+    # A residual of 2 lands in the linear regime for delta=1 (2 - 0.5 = 1.5)
+    # but the quadratic regime for delta=5 (2**2 / 2 = 2.0).
+    predicted = torch.full((4, 1), 2.0)
     true = torch.zeros(4, 1)
     weights = torch.tensor([[1.0], [3.0], [0.5], [2.0]])
 
-    elementwise = torch.nn.functional.huber_loss(predicted, true, reduction="none", delta=2.0)
-    expected = ((weights / weights.mean()) * elementwise).mean()
-    assert torch.allclose(g(predicted, true, weights)[0], expected)
+    out_plain, out_wide = g(predicted, true, weights)
+    assert out_plain.item() == pytest.approx(1.5)
+    assert out_wide.item() == pytest.approx(2.0)  # uniform residuals: weights normalize away


### PR DESCRIPTION
Adds WeightedHuberLoss, following the pattern of WeightedMSELoss and WeightedMAELoss. The weighted module holds torch.nn.HuberLoss(reduction="none") for the huber part and only adds the same weight normalization the other weighted losses use. Both HuberLoss and WeightedHuberLoss take delta (default 1.0, matching torch) — delta is a per-term setting, I train energies and forces with different deltas — and the plain HuberLoss node is built from torch.nn.HuberLoss with the AutoKw mixin. With the default arguments nothing changes for existing users.

Tests are in tests/test_losses.py.
